### PR TITLE
ci: use reusable workflow to build poetry project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,53 +1,16 @@
 name: Main
+
 on:
   push:
     branches: [ main ]
 
 jobs:
-  build-runtime-stdlib:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src
+  poetry-with-codecov:
     strategy:
       matrix:
         python-version: [ "3.10" ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
-        with:
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3.2.3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install library
-        run: poetry install --no-interaction
-
-      # Requires installation of pytest and pytest-cov
-      - name: Test with pytest
-        run: poetry run pytest --doctest-modules --cov=safeds --cov-report=xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: src
-          files: coverage.xml
+    uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
+    with:
+      working-directory: src
+      python-version: ${{ matrix.python-version }}
+      module-name: safeds

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,57 +3,19 @@ name: Pull Request
 on:
   pull_request:
     branches: [ main ]
+  merge_group:
 
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
-  build-runtime-stdlib:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src
+  poetry-with-codecov:
     strategy:
       matrix:
         python-version: [ "3.10" ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
-        with:
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3.2.3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install library
-        run: poetry install --no-interaction
-
-      # Requires installation of pytest and pytest-cov
-      - name: Test with pytest
-        run: poetry run pytest --doctest-modules --cov=safeds --cov-report=xml
-
-      - name: Upload coverage to Codecov
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: src
-          files: coverage.xml
+    uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
+    with:
+      working-directory: src
+      python-version: ${{ matrix.python-version }}
+      module-name: safeds


### PR DESCRIPTION
### Summary of Changes

Use a reusable workflow to build the poetry project and upload coverage to Codecov to reduce code duplication.
