### PR TITLE
ci: use reusable workflow to publish project to PyPI

### DIFF
--- a/.github/workflows/publish_stdlib_to_pypi.yml
+++ b/.github/workflows/publish_stdlib_to_pypi.yml
@@ -4,47 +4,13 @@ on:
   workflow_dispatch
 
 jobs:
-  publish-stdlib:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: src
+  poetry-with-codecov:
     strategy:
       matrix:
         python-version: [ "3.10" ]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
-        with:
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3.2.3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install library
-        run: poetry install --no-interaction
-
-      - name: Test with pytest
-        run: poetry run pytest --doctest-modules
-
-      - name: Publish
-        run: poetry publish --build
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+    uses: lars-reimann/.github/.github/workflows/poetry-pypi-reusable.yml@main
+    with:
+      working-directory: src
+      python-version: ${{ matrix.python-version }}
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
### Summary of Changes

Use reusable workflow to publish project to PyPI.
