### PR TITLE
docs: remove outdated information from homepage of documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,6 @@
 # Safe-DS Python Library
 
 * [Tutorials][tutorials]: Detailed explanations how to use specific parts of the library.
-* [API Reference][api-reference]: An overview of the API of this library.
+* API Reference (link in navigation bar): An overview of the API of this library.
 
 [tutorials]: tutorials/README.md
-[api-reference]: reference/SUMMARY.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,7 @@
-# Safe-DS Documentation
+# Safe-DS Python Library
 
-## For Users
+* [API Reference][api-reference]: An overview of the API of this library.
+* [Tutorials][tutorials]: Detailed explanations how to use specific parts of the library.
 
-* [DSL][dsl]: Documentation of the Safe-DS DSL.
-* [Stdlib][stdlib]: Overview of the elements in the Safe-DS standard library.
-
-## For Developers
-
-* [Development Guides][developers]
-
-[dsl]: DSL/README.md
-[stdlib]: Stdlib/API/README.md
-[developers]: Development/README.md
+[api-reference]: reference/
+[tutorials]: tutorials/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Safe-DS Python Library
 
-* [API Reference][api-reference]: An overview of the API of this library.
 * [Tutorials][tutorials]: Detailed explanations how to use specific parts of the library.
+* [API Reference][api-reference]: An overview of the API of this library.
 
-[api-reference]: reference/
 [tutorials]: tutorials/README.md
+[api-reference]: reference/SUMMARY.md

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -5,5 +5,3 @@
 -   [Data processing](./data_processing.md)
 -   [Data visualization](./visualization.md)
 -   [Machine Learning](./machine_learning.md)
-
----

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ repo_name: Safe-DS/Stdlib
 nav:
   - Home: README.md
   - API Reference: reference/
-  - Tutorials: Tutorials/README.md
+  - Tutorials: tutorials/README.md
 
 # Configuration of MkDocs & Material for MkDocs --------------------------------
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,8 @@ repo_name: Safe-DS/Stdlib
 
 nav:
   - Home: README.md
-  - API Reference: reference/
   - Tutorials: tutorials/README.md
+  - API Reference: reference/
 
 # Configuration of MkDocs & Material for MkDocs --------------------------------
 


### PR DESCRIPTION
### Summary of Changes

The homepage of the documentation was linking to documentation of the DSL. These links are now removed. We'll add more content to the homepage in a later PR.
