### PR TITLE
ci: split PR and merge queue workflows

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -1,12 +1,7 @@
-name: Pull Request
+name: Merge Queue
 
 on:
-  pull_request:
-    branches: [ main ]
-
-concurrency:
-  group: ${{ github.head_ref }}-${{ github.workflow }}
-  cancel-in-progress: true
+  merge_group:
 
 jobs:
   poetry-with-codecov:


### PR DESCRIPTION
### Summary of Changes

Our concurrency configuration for PRs does not work for merge queues since the `head_ref` is always blank, leading to incorrectly cancelled jobs. This PR, therefore, adds another workflow for the merge queue without concurrency.