### PR TITLE
ci: don't compute test coverage in merge queue workflow

### DIFF
--- a/.github/workflows/merge_queue.yml
+++ b/.github/workflows/merge_queue.yml
@@ -13,3 +13,4 @@ jobs:
       working-directory: src
       python-version: ${{ matrix.python-version }}
       module-name: safeds
+      coverage: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,3 +18,5 @@ jobs:
       working-directory: src
       python-version: ${{ matrix.python-version }}
       module-name: safeds
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Summary of Changes

* No longer compute test coverage in the merge queue workflow, which should speed it up slightly.