### PR TITLE
ci: remove CODECOV_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,3 @@ jobs:
       working-directory: src
       python-version: ${{ matrix.python-version }}
       module-name: safeds
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,5 +18,3 @@ jobs:
       working-directory: src
       python-version: ${{ matrix.python-version }}
       module-name: safeds
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Summary of Changes

Remove explicit `CODECOV_TOKEN`, since it's not needed for public repos.