### PR TITLE
docs: better headings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Safe-DS Stdlib
+# Safe-DS Python Library
 
 [![PyPI](https://img.shields.io/pypi/v/safe-ds)](https://pypi.org/project/safe-ds/)
 [![Main](https://github.com/Safe-DS/Stdlib/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Stdlib/actions/workflows/main.yml)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Safe-DS Stdlib
+site_name: Safe-DS Python Library
 repo_url: https://github.com/Safe-DS/Stdlib
 repo_name: Safe-DS/Stdlib
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,7 @@
-# Safe-DS Stdlib
+# Safe-DS Python Library
 
 [![PyPI](https://img.shields.io/pypi/v/safe-ds)](https://pypi.org/project/safe-ds/)
-[![Main](https://github.com/lars-reimann/Safe-DS/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Stdlib/actions/workflows/main.yml)
+[![Main](https://github.com/Safe-DS/Stdlib/actions/workflows/main.yml/badge.svg)](https://github.com/Safe-DS/Stdlib/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/Safe-DS/Stdlib/branch/main/graph/badge.svg?token=HVRP1633B1)](https://codecov.io/gh/Safe-DS/Stdlib)
 [![Documentation Status](https://readthedocs.org/projects/safe-ds-stdlib/badge/?version=latest)](https://safe-ds-stdlib.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
### Summary of Changes

The term "stdlib" makes sense from the perspective of the entire project. For someone who just wants to use the Python components, however, we should instead talk about the "Safe-DS Python Library".
