### PR TITLE
docs: use default symbol for permalinks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,7 +116,7 @@ markdown_extensions:
 
   # Permalinks
   - toc:
-      permalink: "#"
+      permalink: true
 
 extra_javascript:
   - javascript/mathjax.js


### PR DESCRIPTION
### Summary of Changes

Use default symbol for permalinks since changing them doesn't work in notebooks. This gives us a consistent look at least.
