### PR TITLE
ci: also build with Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   poetry-with-codecov:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,12 @@ jobs:
   poetry-with-codecov:
     strategy:
       matrix:
-        python-version: [ "3.10" ]
+        python-version:
+          - "3.10"
+          - "3.11"
     uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
       module-name: safeds
+      coverage: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,9 +12,12 @@ jobs:
   poetry-with-codecov:
     strategy:
       matrix:
-        python-version: [ "3.10" ]
+        python-version:
+          - "3.10"
+          - "3.11"
     uses: lars-reimann/.github/.github/workflows/poetry-codecov-reusable.yml@main
     with:
       working-directory: .
       python-version: ${{ matrix.python-version }}
       module-name: safeds
+      coverage: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   poetry-with-codecov:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"


### PR DESCRIPTION
### Summary of Changes

We support Python 3.11, so we should also ensure the library can be used with it.