### PR TITLE
test: make tests independent of working directory

### DIFF
--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+from ._resources import resolve_resource_path

--- a/tests/fixtures/_resources.py
+++ b/tests/fixtures/_resources.py
@@ -1,0 +1,21 @@
+import os
+
+_resources_root = os.path.join(os.path.dirname(__file__), '..', 'resources')
+
+
+def resolve_resource_path(resource_path: str) -> str:
+    """
+    Resolves a path relative to the `resources` directory to an absolute path.
+
+    Parameters
+    ----------
+    resource_path : str
+        The path to the resource relative to the `resources` directory.
+
+    Returns
+    -------
+    absolute_path : str
+        The absolute path to the resource.
+    """
+
+    return os.path.join(_resources_root, resource_path)

--- a/tests/fixtures/_resources.py
+++ b/tests/fixtures/_resources.py
@@ -1,6 +1,6 @@
 import os
 
-_resources_root = os.path.join(os.path.dirname(__file__), '..', 'resources')
+_resources_root = os.path.join(os.path.dirname(__file__), "..", "resources")
 
 
 def resolve_resource_path(resource_path: str) -> str:

--- a/tests/safeds/data/tabular/containers/_row/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_row/test_has_column.py
@@ -1,13 +1,14 @@
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 
 
 def test_has_column_positive() -> None:
-    table = Table.from_csv("tests/resources/test_table_has_column.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_has_column.csv"))
     row = table.to_rows()[0]
     assert row.has_column("A")
 
 
 def test_has_column_negative() -> None:
-    table = Table.from_csv("tests/resources/test_table_has_column.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_has_column.csv"))
     row = table.to_rows()[0]
     assert not row.has_column("C")

--- a/tests/safeds/data/tabular/containers/_row/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_row/test_has_column.py
@@ -1,5 +1,5 @@
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
+from tests.fixtures import resolve_resource_path
 
 
 def test_has_column_positive() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_column_drop.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_drop.py
@@ -1,10 +1,12 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import UnknownColumnNameError
 
 
 def test_table_column_drop() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     transformed_table = table.drop_columns(["A"])
     assert transformed_table.schema.has_column(
         "B"
@@ -12,6 +14,6 @@ def test_table_column_drop() -> None:
 
 
 def test_table_column_drop_warning() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     with pytest.raises(UnknownColumnNameError):
         table.drop_columns(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_column_drop.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_drop.py
@@ -1,8 +1,7 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import UnknownColumnNameError
+from tests.fixtures import resolve_resource_path
 
 
 def test_table_column_drop() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_column_keep.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_keep.py
@@ -1,8 +1,7 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import UnknownColumnNameError
+from tests.fixtures import resolve_resource_path
 
 
 def test_table_column_keep() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_column_keep.py
+++ b/tests/safeds/data/tabular/containers/_table/test_column_keep.py
@@ -1,10 +1,12 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import UnknownColumnNameError
 
 
 def test_table_column_keep() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     transformed_table = table.keep_columns(["A"])
     assert transformed_table.schema.has_column(
         "A"
@@ -12,6 +14,6 @@ def test_table_column_keep() -> None:
 
 
 def test_table_column_keep_warning() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     with pytest.raises(UnknownColumnNameError):
         table.keep_columns(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_drop_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_drop_duplicate_rows.py
@@ -1,17 +1,19 @@
 import pandas as pd
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 
 
 @pytest.mark.parametrize(
     "path",
     [
-        "tests/resources/test_table_duplicate_rows_duplicates.csv",
-        "tests/resources/test_table_duplicate_rows_no_duplicates.csv",
+        "test_table_duplicate_rows_duplicates.csv",
+        "test_table_duplicate_rows_no_duplicates.csv",
     ],
 )
 def test_drop_duplicate_rows(path: str) -> None:
     expected_table = Table(pd.DataFrame(data={"A": [1, 4], "B": [2, 5]}))
-    table = Table.from_csv(path)
+    table = Table.from_csv(resolve_resource_path(path))
     result_table = table.drop_duplicate_rows()
     assert expected_table == result_table

--- a/tests/safeds/data/tabular/containers/_table/test_drop_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_drop_duplicate_rows.py
@@ -1,8 +1,7 @@
 import pandas as pd
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
+from tests.fixtures import resolve_resource_path
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,9 +1,8 @@
 import pandas as pd
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import MissingDataError
+from tests.fixtures import resolve_resource_path
 
 
 def test_from_columns() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,11 +1,13 @@
 import pandas as pd
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import MissingDataError
 
 
 def test_from_columns() -> None:
-    table_expected = Table.from_csv("tests/resources/test_column_table.csv")
+    table_expected = Table.from_csv(resolve_resource_path("test_column_table.csv"))
     columns_table: list[Column] = [
         Column(pd.Series([1, 4]), "A"),
         Column(pd.Series([2, 5]), "B"),

--- a/tests/safeds/data/tabular/containers/_table/test_from_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_rows.py
@@ -1,8 +1,7 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Row, Table
 from safeds.exceptions import MissingDataError
+from tests.fixtures import resolve_resource_path
 
 
 def test_from_rows() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_from_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_rows.py
@@ -1,10 +1,12 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Row, Table
 from safeds.exceptions import MissingDataError
 
 
 def test_from_rows() -> None:
-    table_expected = Table.from_csv("tests/resources/test_row_table.csv")
+    table_expected = Table.from_csv(resolve_resource_path("test_row_table.csv"))
     rows_is: list[Row] = table_expected.to_rows()
     table_is: Table = Table.from_rows(rows_is)
 

--- a/tests/safeds/data/tabular/containers/_table/test_get_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_get_row.py
@@ -1,21 +1,23 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import IndexOutOfBoundsError
 
 
 def test_get_row() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     val = table.get_row(0)
     assert val.get_value("A") == 1 and val.get_value("B") == 2
 
 
 def test_get_row_negative_index() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     with pytest.raises(IndexOutOfBoundsError):
         table.get_row(-1)
 
 
 def test_get_row_out_of_bounds_index() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     with pytest.raises(IndexOutOfBoundsError):
         table.get_row(5)

--- a/tests/safeds/data/tabular/containers/_table/test_get_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_get_row.py
@@ -1,8 +1,7 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import IndexOutOfBoundsError
+from tests.fixtures import resolve_resource_path
 
 
 def test_get_row() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_has_column.py
@@ -1,11 +1,12 @@
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 
 
 def test_has_column_positive() -> None:
-    table = Table.from_csv("tests/resources/test_table_has_column.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_has_column.csv"))
     assert table.has_column("A")
 
 
 def test_has_column_negative() -> None:
-    table = Table.from_csv("tests/resources/test_table_has_column.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_has_column.csv"))
     assert not table.has_column("C")

--- a/tests/safeds/data/tabular/containers/_table/test_has_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_has_column.py
@@ -1,5 +1,5 @@
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
+from tests.fixtures import resolve_resource_path
 
 
 def test_has_column_positive() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_read_csv.py
+++ b/tests/safeds/data/tabular/containers/_table/test_read_csv.py
@@ -1,7 +1,6 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
+from tests.fixtures import resolve_resource_path
 
 
 def test_read_csv_valid() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_read_csv.py
+++ b/tests/safeds/data/tabular/containers/_table/test_read_csv.py
@@ -1,9 +1,11 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 
 
 def test_read_csv_valid() -> None:
-    table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     assert (
         table.get_column("A").get_value(0) == 1
         and table.get_column("B").get_value(0) == 2
@@ -12,4 +14,4 @@ def test_read_csv_valid() -> None:
 
 def test_read_csv_invalid() -> None:
     with pytest.raises(FileNotFoundError):
-        Table.from_csv("tests/resources/test_table_read_csv_invalid.csv")
+        Table.from_csv(resolve_resource_path("test_table_read_csv_invalid.csv"))

--- a/tests/safeds/data/tabular/containers/_table/test_read_json.py
+++ b/tests/safeds/data/tabular/containers/_table/test_read_json.py
@@ -1,9 +1,11 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 
 
 def test_read_json_valid() -> None:
-    table = Table.from_json("tests/resources/test_table_read_json.json")
+    table = Table.from_json(resolve_resource_path("test_table_read_json.json"))
     assert (
         table.get_column("A").get_value(0) == 1
         and table.get_column("B").get_value(0) == 2
@@ -12,4 +14,4 @@ def test_read_json_valid() -> None:
 
 def test_read_json_invalid() -> None:
     with pytest.raises(FileNotFoundError):
-        Table.from_json("tests/resources/test_table_read_json_invalid.json")
+        Table.from_json(resolve_resource_path("test_table_read_json_invalid.json"))

--- a/tests/safeds/data/tabular/containers/_table/test_read_json.py
+++ b/tests/safeds/data/tabular/containers/_table/test_read_json.py
@@ -1,7 +1,6 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
+from tests.fixtures import resolve_resource_path
 
 
 def test_read_json_valid() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_rename.py
+++ b/tests/safeds/data/tabular/containers/_table/test_rename.py
@@ -1,8 +1,7 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import DuplicateColumnNameError, UnknownColumnNameError
+from tests.fixtures import resolve_resource_path
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/containers/_table/test_rename.py
+++ b/tests/safeds/data/tabular/containers/_table/test_rename.py
@@ -1,4 +1,6 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import DuplicateColumnNameError, UnknownColumnNameError
 
@@ -10,7 +12,7 @@ from safeds.exceptions import DuplicateColumnNameError, UnknownColumnNameError
 def test_rename_valid(
     name_from: str, name_to: str, column_one: str, column_two: str
 ) -> None:
-    table: Table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table: Table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     renamed_table = table.rename_column(name_from, name_to)
     assert renamed_table.schema.has_column(column_one)
     assert renamed_table.schema.has_column(column_two)
@@ -26,6 +28,6 @@ def test_rename_valid(
     ],
 )
 def test_rename_invalid(name_from: str, name_to: str, error: Exception) -> None:
-    table: Table = Table.from_csv("tests/resources/test_table_read_csv.csv")
+    table: Table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     with pytest.raises(error):
         table.rename_column(name_from, name_to)

--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import (
     ColumnSizeError,
@@ -11,15 +13,15 @@ from safeds.exceptions import (
 @pytest.mark.parametrize(
     "column_name, path",
     [
-        ("C", "tests/resources/test_table_replace_column_output_different_name.csv"),
-        ("D", "tests/resources/test_table_replace_column_output_same_name.csv"),
+        ("C", "test_table_replace_column_output_different_name.csv"),
+        ("D", "test_table_replace_column_output_same_name.csv"),
     ],
 )
 def test_replace_valid(column_name: str, path: str) -> None:
     input_table: Table = Table.from_csv(
-        "tests/resources/test_table_replace_column_input.csv"
+        resolve_resource_path("test_table_replace_column_input.csv")
     )
-    expected: Table = Table.from_csv(path)
+    expected: Table = Table.from_csv(resolve_resource_path(path))
 
     column = Column(pd.Series(["d", "e", "f"]), column_name)
 
@@ -43,7 +45,7 @@ def test_replace_invalid(
     error: type[Exception],
 ) -> None:
     input_table: Table = Table.from_csv(
-        "tests/resources/test_table_replace_column_input.csv"
+        resolve_resource_path("test_table_replace_column_input.csv")
     )
     column = Column(pd.Series(column_values), column_name)
 

--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -1,13 +1,12 @@
 import pandas as pd
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import (
     ColumnSizeError,
     DuplicateColumnNameError,
     UnknownColumnNameError,
 )
+from tests.fixtures import resolve_resource_path
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
@@ -1,14 +1,16 @@
 import pandas as pd
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import ColumnSizeError, DuplicateColumnNameError
 
 
 def test_table_add_column_valid() -> None:
     input_table = Table.from_csv(
-        "tests/resources/test_table_add_column_valid_input.csv"
+        resolve_resource_path("test_table_add_column_valid_input.csv")
     )
-    expected = Table.from_csv("tests/resources/test_table_add_column_valid_output.csv")
+    expected = Table.from_csv(resolve_resource_path("test_table_add_column_valid_output.csv"))
     column = Column(pd.Series(["a", "b", "c"]), "C")
 
     result = input_table.add_column(column)
@@ -26,7 +28,7 @@ def test_table_add_column_(
     column_values: list[str], column_name: str, error: type[Exception]
 ) -> None:
     input_table = Table.from_csv(
-        "tests/resources/test_table_add_column_valid_input.csv"
+        resolve_resource_path("test_table_add_column_valid_input.csv")
     )
     column = Column(pd.Series(column_values), column_name)
 

--- a/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
@@ -1,16 +1,17 @@
 import pandas as pd
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 from safeds.exceptions import ColumnSizeError, DuplicateColumnNameError
+from tests.fixtures import resolve_resource_path
 
 
 def test_table_add_column_valid() -> None:
     input_table = Table.from_csv(
         resolve_resource_path("test_table_add_column_valid_input.csv")
     )
-    expected = Table.from_csv(resolve_resource_path("test_table_add_column_valid_output.csv"))
+    expected = Table.from_csv(
+        resolve_resource_path("test_table_add_column_valid_output.csv")
+    )
     column = Column(pd.Series(["a", "b", "c"]), "C")
 
     result = input_table.add_column(column)

--- a/tests/safeds/data/tabular/containers/_table/test_to_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_columns.py
@@ -1,8 +1,7 @@
 import pandas as pd
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
+from tests.fixtures import resolve_resource_path
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/containers/_table/test_to_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_columns.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Column, Table
 
 
@@ -8,7 +10,7 @@ from safeds.data.tabular.containers import Column, Table
     [([1, 4], "A", 0), ([2, 5], "B", 1)],
 )
 def test_to_columns(values: list[int], name: str, index: int) -> None:
-    table = Table.from_csv("tests/resources/test_column_table.csv")
+    table = Table.from_csv(resolve_resource_path("test_column_table.csv"))
     columns_list: list[Column] = table.to_columns()
 
     column_expected: Column = Column(pd.Series(values, name=name), name)

--- a/tests/safeds/data/tabular/containers/_table/test_to_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_rows.py
@@ -1,10 +1,12 @@
 import pandas as pd
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.typing import IntColumnType, StringColumnType, TableSchema
 
 
 def test_to_rows() -> None:
-    table = Table.from_csv("tests/resources/test_row_table.csv")
+    table = Table.from_csv(resolve_resource_path("test_row_table.csv"))
     expected_schema: TableSchema = TableSchema(
         {
             "A": IntColumnType(),

--- a/tests/safeds/data/tabular/containers/_table/test_to_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_rows.py
@@ -1,8 +1,7 @@
 import pandas as pd
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.typing import IntColumnType, StringColumnType, TableSchema
+from tests.fixtures import resolve_resource_path
 
 
 def test_to_rows() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_transform_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_transform_column.py
@@ -1,8 +1,7 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import UnknownColumnNameError
+from tests.fixtures import resolve_resource_path
 
 
 def test_transform_column_valid() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_transform_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_transform_column.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.exceptions import UnknownColumnNameError
 
 
 def test_transform_column_valid() -> None:
     input_table: Table = Table.from_csv(
-        "tests/resources/test_table_transform_column.csv"
+        resolve_resource_path("test_table_transform_column.csv")
     )
 
     result: Table = input_table.transform_column(
@@ -13,13 +15,13 @@ def test_transform_column_valid() -> None:
     )
 
     assert result == Table.from_csv(
-        "tests/resources/test_table_transform_column_output.csv"
+        resolve_resource_path("test_table_transform_column_output.csv")
     )
 
 
 def test_transform_column_invalid() -> None:
     input_table: Table = Table.from_csv(
-        "tests/resources/test_table_transform_column.csv"
+        resolve_resource_path("test_table_transform_column.csv")
     )
 
     with pytest.raises(UnknownColumnNameError):

--- a/tests/safeds/data/tabular/containers/_tagged_table/test_feature_vectors.py
+++ b/tests/safeds/data/tabular/containers/_tagged_table/test_feature_vectors.py
@@ -1,5 +1,5 @@
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
+from tests.fixtures import resolve_resource_path
 
 
 def test_tagged_table_feature_vectors() -> None:

--- a/tests/safeds/data/tabular/containers/_tagged_table/test_feature_vectors.py
+++ b/tests/safeds/data/tabular/containers/_tagged_table/test_feature_vectors.py
@@ -1,8 +1,9 @@
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 
 
 def test_tagged_table_feature_vectors() -> None:
-    table = Table.from_csv("tests/resources/test_tagged_table.csv")
+    table = Table.from_csv(resolve_resource_path("test_tagged_table.csv"))
     tagged_table = TaggedTable(table, "T")
     assert "T" not in tagged_table.feature_vectors._data
     assert tagged_table.feature_vectors.schema.has_column("A")

--- a/tests/safeds/data/tabular/containers/_tagged_table/test_target_values.py
+++ b/tests/safeds/data/tabular/containers/_tagged_table/test_target_values.py
@@ -1,8 +1,9 @@
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 
 
 def test_tagged_table_target_values() -> None:
-    table = Table.from_csv("tests/resources/test_tagged_table.csv")
+    table = Table.from_csv(resolve_resource_path("test_tagged_table.csv"))
     tagged_table = TaggedTable(table, "T")
     assert tagged_table.target_values._data[0] == 0
     assert tagged_table.target_values._data[1] == 1

--- a/tests/safeds/data/tabular/containers/_tagged_table/test_target_values.py
+++ b/tests/safeds/data/tabular/containers/_tagged_table/test_target_values.py
@@ -1,5 +1,5 @@
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
+from tests.fixtures import resolve_resource_path
 
 
 def test_tagged_table_target_values() -> None:

--- a/tests/safeds/data/tabular/typing/_table_schema/test_get_column_type.py
+++ b/tests/safeds/data/tabular/typing/_table_schema/test_get_column_type.py
@@ -1,8 +1,7 @@
 import numpy as np
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import ColumnType
+from tests.fixtures import resolve_resource_path
 
 
 def test_get_type_of_column() -> None:

--- a/tests/safeds/data/tabular/typing/_table_schema/test_get_column_type.py
+++ b/tests/safeds/data/tabular/typing/_table_schema/test_get_column_type.py
@@ -1,9 +1,11 @@
 import numpy as np
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import ColumnType
 
 
 def test_get_type_of_column() -> None:
-    table = Table.from_json("tests/resources/test_schema_table.json")
+    table = Table.from_json(resolve_resource_path("test_schema_table.json"))
     table_column_type = table.schema.get_type_of_column("A")
     assert table_column_type == ColumnType.from_numpy_dtype(np.dtype("int64"))

--- a/tests/safeds/data/tabular/typing/_table_schema/test_has_column.py
+++ b/tests/safeds/data/tabular/typing/_table_schema/test_has_column.py
@@ -1,13 +1,14 @@
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 
 
 def test_has_column_true() -> None:
-    table = Table.from_json("tests/resources/test_schema_table.json")
+    table = Table.from_json(resolve_resource_path("test_schema_table.json"))
 
     assert table.schema.has_column("A")
 
 
 def test_has_column_false() -> None:
-    table = Table.from_json("tests/resources/test_schema_table.json")
+    table = Table.from_json(resolve_resource_path("test_schema_table.json"))
 
     assert not table.schema.has_column("C")

--- a/tests/safeds/data/tabular/typing/_table_schema/test_has_column.py
+++ b/tests/safeds/data/tabular/typing/_table_schema/test_has_column.py
@@ -1,5 +1,5 @@
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
+from tests.fixtures import resolve_resource_path
 
 
 def test_has_column_true() -> None:

--- a/tests/safeds/data/tabular/typing/_table_schema/test_table_equals.py
+++ b/tests/safeds/data/tabular/typing/_table_schema/test_table_equals.py
@@ -1,6 +1,6 @@
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import FloatColumnType, IntColumnType, TableSchema
+from tests.fixtures import resolve_resource_path
 
 
 def test_table_equals_valid() -> None:

--- a/tests/safeds/data/tabular/typing/_table_schema/test_table_equals.py
+++ b/tests/safeds/data/tabular/typing/_table_schema/test_table_equals.py
@@ -1,9 +1,10 @@
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import FloatColumnType, IntColumnType, TableSchema
 
 
 def test_table_equals_valid() -> None:
-    table = Table.from_json("tests/resources/test_schema_table.json")
+    table = Table.from_json(resolve_resource_path("test_schema_table.json"))
     schema_expected = TableSchema(
         {
             "A": IntColumnType(),
@@ -15,7 +16,7 @@ def test_table_equals_valid() -> None:
 
 
 def test_table_equals_invalid() -> None:
-    table = Table.from_json("tests/resources/test_schema_table.json")
+    table = Table.from_json(resolve_resource_path("test_schema_table.json"))
     schema_not_expected = TableSchema(
         {
             "A": FloatColumnType(),

--- a/tests/safeds/ml/classification/_ada_boost/test_fit.py
+++ b/tests/safeds/ml/classification/_ada_boost/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import AdaBoost
+from tests.fixtures import resolve_resource_path
 
 
 def test_ada_boost_fit() -> None:

--- a/tests/safeds/ml/classification/_ada_boost/test_fit.py
+++ b/tests/safeds/ml/classification/_ada_boost/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import AdaBoost
 
 
 def test_ada_boost_fit() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     ada_boost.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_ada_boost_fit() -> None:
 
 
 def test_ada_boost_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_ada_boost/test_predict.py
+++ b/tests/safeds/ml/classification/_ada_boost/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import AdaBoost
 
 
 def test_ada_boost_predict() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     ada_boost.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_ada_boost_predict() -> None:
 
 
 def test_ada_boost_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_ada_boost_predict_not_fitted() -> None:
 
 
 def test_ada_boost_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
-    invalid_table = Table.from_csv("tests/resources/test_ada_boost_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_ada_boost_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     ada_boost = AdaBoost()

--- a/tests/safeds/ml/classification/_ada_boost/test_predict.py
+++ b/tests/safeds/ml/classification/_ada_boost/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import AdaBoost
+from tests.fixtures import resolve_resource_path
 
 
 def test_ada_boost_predict() -> None:

--- a/tests/safeds/ml/classification/_decision_tree/test_fit.py
+++ b/tests/safeds/ml/classification/_decision_tree/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import DecisionTree
 
 
 def test_decision_tree_fit() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     decision_tree.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_decision_tree_fit() -> None:
 
 
 def test_decision_tree_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_decision_tree/test_fit.py
+++ b/tests/safeds/ml/classification/_decision_tree/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import DecisionTree
+from tests.fixtures import resolve_resource_path
 
 
 def test_decision_tree_fit() -> None:

--- a/tests/safeds/ml/classification/_decision_tree/test_predict.py
+++ b/tests/safeds/ml/classification/_decision_tree/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import DecisionTree
+from tests.fixtures import resolve_resource_path
 
 
 def test_decision_tree_predict() -> None:
@@ -25,7 +24,9 @@ def test_decision_tree_predict_not_fitted() -> None:
 
 def test_decision_tree_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_decision_tree_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_decision_tree_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     decision_tree = DecisionTree()

--- a/tests/safeds/ml/classification/_decision_tree/test_predict.py
+++ b/tests/safeds/ml/classification/_decision_tree/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import DecisionTree
 
 
 def test_decision_tree_predict() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     decision_tree.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_decision_tree_predict() -> None:
 
 
 def test_decision_tree_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_decision_tree_predict_not_fitted() -> None:
 
 
 def test_decision_tree_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
-    invalid_table = Table.from_csv("tests/resources/test_decision_tree_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_decision_tree_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     decision_tree = DecisionTree()

--- a/tests/safeds/ml/classification/_gradient_boosting/test_fit.py
+++ b/tests/safeds/ml/classification/_gradient_boosting/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import GradientBoosting
 
 
 def test_gradient_boosting_classification_fit() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_classification.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_classification = GradientBoosting()
     gradient_boosting_classification.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_gradient_boosting_classification_fit() -> None:
 
 def test_gradient_boosting_classification_fit_invalid() -> None:
     table = Table.from_csv(
-        "tests/resources/test_gradient_boosting_classification_invalid.csv"
+        resolve_resource_path("test_gradient_boosting_classification_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_classification = GradientBoosting()

--- a/tests/safeds/ml/classification/_gradient_boosting/test_fit.py
+++ b/tests/safeds/ml/classification/_gradient_boosting/test_fit.py
@@ -1,13 +1,14 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import GradientBoosting
+from tests.fixtures import resolve_resource_path
 
 
 def test_gradient_boosting_classification_fit() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_classification.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_classification = GradientBoosting()
     gradient_boosting_classification.fit(tagged_table)

--- a/tests/safeds/ml/classification/_gradient_boosting/test_predict.py
+++ b/tests/safeds/ml/classification/_gradient_boosting/test_predict.py
@@ -1,13 +1,14 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import GradientBoosting
+from tests.fixtures import resolve_resource_path
 
 
 def test_gradient_boosting_predict() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_classification.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_classification = GradientBoosting()
     gradient_boosting_classification.fit(tagged_table)
@@ -16,7 +17,9 @@ def test_gradient_boosting_predict() -> None:
 
 
 def test_gradient_boosting_predict_not_fitted() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_classification.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting = GradientBoosting()
     with pytest.raises(PredictionError):
@@ -24,7 +27,9 @@ def test_gradient_boosting_predict_not_fitted() -> None:
 
 
 def test_gradient_boosting_predict_invalid() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_classification.csv")
+    )
     invalid_table = Table.from_csv(
         resolve_resource_path("test_gradient_boosting_classification_invalid.csv")
     )

--- a/tests/safeds/ml/classification/_gradient_boosting/test_predict.py
+++ b/tests/safeds/ml/classification/_gradient_boosting/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import GradientBoosting
 
 
 def test_gradient_boosting_predict() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_classification.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_classification = GradientBoosting()
     gradient_boosting_classification.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_gradient_boosting_predict() -> None:
 
 
 def test_gradient_boosting_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_classification.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
     tagged_table = TaggedTable(table, "T")
     gradient_boosting = GradientBoosting()
     with pytest.raises(PredictionError):
@@ -22,9 +24,9 @@ def test_gradient_boosting_predict_not_fitted() -> None:
 
 
 def test_gradient_boosting_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_classification.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_classification.csv"))
     invalid_table = Table.from_csv(
-        "tests/resources/test_gradient_boosting_classification_invalid.csv"
+        resolve_resource_path("test_gradient_boosting_classification_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")

--- a/tests/safeds/ml/classification/_k_nearest_neighbors/test_fit.py
+++ b/tests/safeds/ml/classification/_k_nearest_neighbors/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import KNearestNeighbors as KNearestNeighborsClassifier
+from tests.fixtures import resolve_resource_path
 
 
 def test_k_nearest_neighbors_fit() -> None:
@@ -15,7 +14,9 @@ def test_k_nearest_neighbors_fit() -> None:
 
 
 def test_k_nearest_neighbors_fit_invalid() -> None:
-    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors_invalid.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_k_nearest_neighbors_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsClassifier(2)
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_k_nearest_neighbors/test_fit.py
+++ b/tests/safeds/ml/classification/_k_nearest_neighbors/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import KNearestNeighbors as KNearestNeighborsClassifier
 
 
 def test_k_nearest_neighbors_fit() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsClassifier(2)
     k_nearest_neighbors.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_k_nearest_neighbors_fit() -> None:
 
 
 def test_k_nearest_neighbors_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsClassifier(2)
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_k_nearest_neighbors/test_predict.py
+++ b/tests/safeds/ml/classification/_k_nearest_neighbors/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import KNearestNeighbors as KNearestNeighborsClassifier
+from tests.fixtures import resolve_resource_path
 
 
 def test_k_nearest_neighbors_predict() -> None:

--- a/tests/safeds/ml/classification/_k_nearest_neighbors/test_predict.py
+++ b/tests/safeds/ml/classification/_k_nearest_neighbors/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import KNearestNeighbors as KNearestNeighborsClassifier
 
 
 def test_k_nearest_neighbors_predict() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsClassifier(2)
     k_nearest_neighbors.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_k_nearest_neighbors_predict() -> None:
 
 
 def test_k_nearest_neighbors_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsClassifier(2)
     with pytest.raises(PredictionError):
@@ -22,9 +24,9 @@ def test_k_nearest_neighbors_predict_not_fitted() -> None:
 
 
 def test_k_nearest_neighbors_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     invalid_table = Table.from_csv(
-        "tests/resources/test_k_nearest_neighbors_invalid.csv"
+        resolve_resource_path("test_k_nearest_neighbors_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")

--- a/tests/safeds/ml/classification/_logistic_regression/test_fit.py
+++ b/tests/safeds/ml/classification/_logistic_regression/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import LogisticRegression
 
 
 def test_logistic_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_logistic_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_logistic_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     log_regression = LogisticRegression()
     log_regression.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_logistic_regression_fit() -> None:
 
 
 def test_logistic_regression_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_logistic_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_logistic_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     log_regression = LogisticRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_logistic_regression/test_fit.py
+++ b/tests/safeds/ml/classification/_logistic_regression/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import LogisticRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_logistic_regression_fit() -> None:
@@ -15,7 +14,9 @@ def test_logistic_regression_fit() -> None:
 
 
 def test_logistic_regression_fit_invalid() -> None:
-    table = Table.from_csv(resolve_resource_path("test_logistic_regression_invalid.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_logistic_regression_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     log_regression = LogisticRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_logistic_regression/test_predict.py
+++ b/tests/safeds/ml/classification/_logistic_regression/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import LogisticRegression
 
 
 def test_logistic_regression_predict() -> None:
-    table = Table.from_csv("tests/resources/test_logistic_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_logistic_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     log_regression = LogisticRegression()
     log_regression.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_logistic_regression_predict() -> None:
 
 
 def test_logistic_regression_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_logistic_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_logistic_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     log_regression = LogisticRegression()
     with pytest.raises(PredictionError):
@@ -22,9 +24,9 @@ def test_logistic_regression_predict_not_fitted() -> None:
 
 
 def test_logistic_regression_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_logistic_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_logistic_regression.csv"))
     invalid_table = Table.from_csv(
-        "tests/resources/test_logistic_regression_invalid.csv"
+        resolve_resource_path("test_logistic_regression_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")

--- a/tests/safeds/ml/classification/_logistic_regression/test_predict.py
+++ b/tests/safeds/ml/classification/_logistic_regression/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import LogisticRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_logistic_regression_predict() -> None:

--- a/tests/safeds/ml/classification/_random_forest/test_fit.py
+++ b/tests/safeds/ml/classification/_random_forest/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import RandomForest as RandomForestClassifier
+from tests.fixtures import resolve_resource_path
 
 
 def test_logistic_regression_fit() -> None:

--- a/tests/safeds/ml/classification/_random_forest/test_fit.py
+++ b/tests/safeds/ml/classification/_random_forest/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.classification import RandomForest as RandomForestClassifier
 
 
 def test_logistic_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestClassifier()
     random_forest.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_logistic_regression_fit() -> None:
 
 
 def test_logistic_regression_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestClassifier()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/classification/_random_forest/test_predict.py
+++ b/tests/safeds/ml/classification/_random_forest/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import RandomForest as RandomForestClassifier
 
 
 def test_random_forest_predict() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestClassifier()
     random_forest.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_random_forest_predict() -> None:
 
 
 def test_random_forest_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestClassifier()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_random_forest_predict_not_fitted() -> None:
 
 
 def test_random_forest_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
-    invalid_table = Table.from_csv("tests/resources/test_random_forest_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_random_forest_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     random_forest = RandomForestClassifier()

--- a/tests/safeds/ml/classification/_random_forest/test_predict.py
+++ b/tests/safeds/ml/classification/_random_forest/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.classification import RandomForest as RandomForestClassifier
+from tests.fixtures import resolve_resource_path
 
 
 def test_random_forest_predict() -> None:
@@ -25,7 +24,9 @@ def test_random_forest_predict_not_fitted() -> None:
 
 def test_random_forest_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_random_forest_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_random_forest_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     random_forest = RandomForestClassifier()

--- a/tests/safeds/ml/regression/_ada_boost/test_fit.py
+++ b/tests/safeds/ml/regression/_ada_boost/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import AdaBoost
+from tests.fixtures import resolve_resource_path
 
 
 def test_ada_boost_fit() -> None:

--- a/tests/safeds/ml/regression/_ada_boost/test_fit.py
+++ b/tests/safeds/ml/regression/_ada_boost/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import AdaBoost
 
 
 def test_ada_boost_fit() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     ada_boost.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_ada_boost_fit() -> None:
 
 
 def test_ada_boost_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_ada_boost/test_predict.py
+++ b/tests/safeds/ml/regression/_ada_boost/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import AdaBoost
 
 
 def test_ada_boost_predict() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     ada_boost.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_ada_boost_predict() -> None:
 
 
 def test_ada_boost_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
     tagged_table = TaggedTable(table, "T")
     ada_boost = AdaBoost()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_ada_boost_predict_not_fitted() -> None:
 
 
 def test_ada_boost_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_ada_boost.csv")
-    invalid_table = Table.from_csv("tests/resources/test_ada_boost_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_ada_boost.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_ada_boost_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     ada_boost = AdaBoost()

--- a/tests/safeds/ml/regression/_ada_boost/test_predict.py
+++ b/tests/safeds/ml/regression/_ada_boost/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import AdaBoost
+from tests.fixtures import resolve_resource_path
 
 
 def test_ada_boost_predict() -> None:

--- a/tests/safeds/ml/regression/_decision_tree/test_fit.py
+++ b/tests/safeds/ml/regression/_decision_tree/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import DecisionTree
+from tests.fixtures import resolve_resource_path
 
 
 def test_decision_tree_fit() -> None:

--- a/tests/safeds/ml/regression/_decision_tree/test_fit.py
+++ b/tests/safeds/ml/regression/_decision_tree/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import DecisionTree
 
 
 def test_decision_tree_fit() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     decision_tree.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_decision_tree_fit() -> None:
 
 
 def test_decision_tree_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_decision_tree/test_predict.py
+++ b/tests/safeds/ml/regression/_decision_tree/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import DecisionTree
 
 
 def test_decision_tree_predict() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     decision_tree.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_decision_tree_predict() -> None:
 
 
 def test_decision_tree_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
     tagged_table = TaggedTable(table, "T")
     decision_tree = DecisionTree()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_decision_tree_predict_not_fitted() -> None:
 
 
 def test_decision_tree_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_decision_tree.csv")
-    invalid_table = Table.from_csv("tests/resources/test_decision_tree_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_decision_tree_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     decision_tree = DecisionTree()

--- a/tests/safeds/ml/regression/_decision_tree/test_predict.py
+++ b/tests/safeds/ml/regression/_decision_tree/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import DecisionTree
+from tests.fixtures import resolve_resource_path
 
 
 def test_decision_tree_predict() -> None:
@@ -25,7 +24,9 @@ def test_decision_tree_predict_not_fitted() -> None:
 
 def test_decision_tree_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_decision_tree.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_decision_tree_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_decision_tree_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     decision_tree = DecisionTree()

--- a/tests/safeds/ml/regression/_elastic_net/test_fit.py
+++ b/tests/safeds/ml/regression/_elastic_net/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import ElasticNetRegression
 
 
 def test_elastic_net_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_elastic_net_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_elastic_net_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     en_regression = ElasticNetRegression()
     en_regression.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_elastic_net_regression_fit() -> None:
 
 
 def test_elastic_net_regression_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_elastic_net_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_elastic_net_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     en_regression = ElasticNetRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_elastic_net/test_fit.py
+++ b/tests/safeds/ml/regression/_elastic_net/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import ElasticNetRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_elastic_net_regression_fit() -> None:
@@ -15,7 +14,9 @@ def test_elastic_net_regression_fit() -> None:
 
 
 def test_elastic_net_regression_fit_invalid() -> None:
-    table = Table.from_csv(resolve_resource_path("test_elastic_net_regression_invalid.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_elastic_net_regression_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     en_regression = ElasticNetRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_elastic_net/test_predict.py
+++ b/tests/safeds/ml/regression/_elastic_net/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import ElasticNetRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_elastic_net_regression_predict() -> None:

--- a/tests/safeds/ml/regression/_elastic_net/test_predict.py
+++ b/tests/safeds/ml/regression/_elastic_net/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import ElasticNetRegression
 
 
 def test_elastic_net_regression_predict() -> None:
-    table = Table.from_csv("tests/resources/test_elastic_net_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_elastic_net_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     en_regression = ElasticNetRegression()
     en_regression.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_elastic_net_regression_predict() -> None:
 
 
 def test_elastic_net_regression_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_elastic_net_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_elastic_net_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     en_regression = ElasticNetRegression()
     with pytest.raises(PredictionError):
@@ -22,9 +24,9 @@ def test_elastic_net_regression_predict_not_fitted() -> None:
 
 
 def test_elastic_net_regression_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_elastic_net_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_elastic_net_regression.csv"))
     invalid_table = Table.from_csv(
-        "tests/resources/test_elastic_net_regression_invalid.csv"
+        resolve_resource_path("test_elastic_net_regression_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")

--- a/tests/safeds/ml/regression/_gradient_boosting_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_gradient_boosting_regression/test_fit.py
@@ -1,13 +1,14 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import GradientBoosting
+from tests.fixtures import resolve_resource_path
 
 
 def test_gradient_boosting_regression_fit() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_regression.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting = GradientBoosting()
     gradient_boosting.fit(tagged_table)

--- a/tests/safeds/ml/regression/_gradient_boosting_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_gradient_boosting_regression/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import GradientBoosting
 
 
 def test_gradient_boosting_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     gradient_boosting = GradientBoosting()
     gradient_boosting.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_gradient_boosting_regression_fit() -> None:
 
 def test_gradient_boosting_regression_fit_invalid() -> None:
     table = Table.from_csv(
-        "tests/resources/test_gradient_boosting_regression_invalid.csv"
+        resolve_resource_path("test_gradient_boosting_regression_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_regression = GradientBoosting()

--- a/tests/safeds/ml/regression/_gradient_boosting_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_gradient_boosting_regression/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import GradientBoosting
 
 
 def test_gradient_boosting_predict() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_regression = GradientBoosting()
     gradient_boosting_regression.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_gradient_boosting_predict() -> None:
 
 
 def test_gradient_boosting_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_regression = GradientBoosting()
     with pytest.raises(PredictionError):
@@ -22,9 +24,9 @@ def test_gradient_boosting_predict_not_fitted() -> None:
 
 
 def test_gradient_boosting_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_gradient_boosting_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
     invalid_table = Table.from_csv(
-        "tests/resources/test_gradient_boosting_regression_invalid.csv"
+        resolve_resource_path("test_gradient_boosting_regression_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")

--- a/tests/safeds/ml/regression/_gradient_boosting_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_gradient_boosting_regression/test_predict.py
@@ -1,13 +1,14 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import GradientBoosting
+from tests.fixtures import resolve_resource_path
 
 
 def test_gradient_boosting_predict() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_regression.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_regression = GradientBoosting()
     gradient_boosting_regression.fit(tagged_table)
@@ -16,7 +17,9 @@ def test_gradient_boosting_predict() -> None:
 
 
 def test_gradient_boosting_predict_not_fitted() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_regression.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     gradient_boosting_regression = GradientBoosting()
     with pytest.raises(PredictionError):
@@ -24,7 +27,9 @@ def test_gradient_boosting_predict_not_fitted() -> None:
 
 
 def test_gradient_boosting_predict_invalid() -> None:
-    table = Table.from_csv(resolve_resource_path("test_gradient_boosting_regression.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_gradient_boosting_regression.csv")
+    )
     invalid_table = Table.from_csv(
         resolve_resource_path("test_gradient_boosting_regression_invalid.csv")
     )

--- a/tests/safeds/ml/regression/_k_nearest_neighbors/test_fit.py
+++ b/tests/safeds/ml/regression/_k_nearest_neighbors/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import KNearestNeighbors as KNearestNeighborsRegressor
 
 
 def test_k_nearest_neighbors_fit() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsRegressor(2)
     k_nearest_neighbors.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_k_nearest_neighbors_fit() -> None:
 
 
 def test_k_nearest_neighbors_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsRegressor(2)
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_k_nearest_neighbors/test_fit.py
+++ b/tests/safeds/ml/regression/_k_nearest_neighbors/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import KNearestNeighbors as KNearestNeighborsRegressor
+from tests.fixtures import resolve_resource_path
 
 
 def test_k_nearest_neighbors_fit() -> None:
@@ -15,7 +14,9 @@ def test_k_nearest_neighbors_fit() -> None:
 
 
 def test_k_nearest_neighbors_fit_invalid() -> None:
-    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors_invalid.csv"))
+    table = Table.from_csv(
+        resolve_resource_path("test_k_nearest_neighbors_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsRegressor(2)
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_k_nearest_neighbors/test_predict.py
+++ b/tests/safeds/ml/regression/_k_nearest_neighbors/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import KNearestNeighbors as KNearestNeighborsRegressor
+from tests.fixtures import resolve_resource_path
 
 
 def test_k_nearest_neighbors_predict() -> None:

--- a/tests/safeds/ml/regression/_k_nearest_neighbors/test_predict.py
+++ b/tests/safeds/ml/regression/_k_nearest_neighbors/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import KNearestNeighbors as KNearestNeighborsRegressor
 
 
 def test_k_nearest_neighbors_predict() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsRegressor(2)
     k_nearest_neighbors.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_k_nearest_neighbors_predict() -> None:
 
 
 def test_k_nearest_neighbors_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     tagged_table = TaggedTable(table, "T")
     k_nearest_neighbors = KNearestNeighborsRegressor(2)
     with pytest.raises(PredictionError):
@@ -22,9 +24,9 @@ def test_k_nearest_neighbors_predict_not_fitted() -> None:
 
 
 def test_k_nearest_neighbors_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_k_nearest_neighbors.csv")
+    table = Table.from_csv(resolve_resource_path("test_k_nearest_neighbors.csv"))
     invalid_table = Table.from_csv(
-        "tests/resources/test_k_nearest_neighbors_invalid.csv"
+        resolve_resource_path("test_k_nearest_neighbors_invalid.csv")
     )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")

--- a/tests/safeds/ml/regression/_lasso_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_lasso_regression/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import LassoRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_lasso_regression_fit() -> None:

--- a/tests/safeds/ml/regression/_lasso_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_lasso_regression/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import LassoRegression
 
 
 def test_lasso_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_lasso_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_lasso_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     lasso_regression = LassoRegression()
     lasso_regression.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_lasso_regression_fit() -> None:
 
 
 def test_lasso_regression_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_lasso_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_lasso_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     lasso_regression = LassoRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_lasso_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_lasso_regression/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import LassoRegression
 
 
 def test_lasso_regression_predict() -> None:
-    table = Table.from_csv("tests/resources/test_lasso_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_lasso_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     lasso_regression = LassoRegression()
     lasso_regression.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_lasso_regression_predict() -> None:
 
 
 def test_lasso_regression_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_lasso_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_lasso_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     lasso_regression = LassoRegression()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_lasso_regression_predict_not_fitted() -> None:
 
 
 def test_lasso_regression_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_lasso_regression.csv")
-    invalid_table = Table.from_csv("tests/resources/test_lasso_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_lasso_regression.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_lasso_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     lasso_regression = LassoRegression()

--- a/tests/safeds/ml/regression/_lasso_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_lasso_regression/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import LassoRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_lasso_regression_predict() -> None:
@@ -25,7 +24,9 @@ def test_lasso_regression_predict_not_fitted() -> None:
 
 def test_lasso_regression_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_lasso_regression.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_lasso_regression_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_lasso_regression_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     lasso_regression = LassoRegression()

--- a/tests/safeds/ml/regression/_linear_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_linear_regression/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import LinearRegression
 
 
 def test_linear_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_linear_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_linear_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     linear_regression = LinearRegression()
     linear_regression.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_linear_regression_fit() -> None:
 
 
 def test_linear_regression_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_linear_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_linear_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     linear_regression = LinearRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_linear_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_linear_regression/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import LinearRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_linear_regression_fit() -> None:

--- a/tests/safeds/ml/regression/_linear_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_linear_regression/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import LinearRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_linear_regression_predict() -> None:
@@ -25,7 +24,9 @@ def test_linear_regression_predict_not_fitted() -> None:
 
 def test_linear_regression_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_linear_regression.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_linear_regression_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_linear_regression_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     linear_regression = LinearRegression()

--- a/tests/safeds/ml/regression/_linear_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_linear_regression/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import LinearRegression
 
 
 def test_linear_regression_predict() -> None:
-    table = Table.from_csv("tests/resources/test_linear_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_linear_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     linear_regression = LinearRegression()
     linear_regression.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_linear_regression_predict() -> None:
 
 
 def test_linear_regression_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_linear_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_linear_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     linear_regression = LinearRegression()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_linear_regression_predict_not_fitted() -> None:
 
 
 def test_linear_regression_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_linear_regression.csv")
-    invalid_table = Table.from_csv("tests/resources/test_linear_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_linear_regression.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_linear_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     linear_regression = LinearRegression()

--- a/tests/safeds/ml/regression/_random_forest/test_fit.py
+++ b/tests/safeds/ml/regression/_random_forest/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import RandomForest as RandomForestRegressor
+from tests.fixtures import resolve_resource_path
 
 
 def test_random_forest_fit() -> None:

--- a/tests/safeds/ml/regression/_random_forest/test_fit.py
+++ b/tests/safeds/ml/regression/_random_forest/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import RandomForest as RandomForestRegressor
 
 
 def test_random_forest_fit() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestRegressor()
     random_forest.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_random_forest_fit() -> None:
 
 
 def test_random_forest_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestRegressor()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_random_forest/test_predict.py
+++ b/tests/safeds/ml/regression/_random_forest/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import RandomForest as RandomForestRegressor
 
 
 def test_random_forest_predict() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestRegressor()
     random_forest.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_random_forest_predict() -> None:
 
 
 def test_random_forest_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
     tagged_table = TaggedTable(table, "T")
     random_forest = RandomForestRegressor()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_random_forest_predict_not_fitted() -> None:
 
 
 def test_random_forest_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_random_forest.csv")
-    invalid_table = Table.from_csv("tests/resources/test_random_forest_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_random_forest_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     random_forest = RandomForestRegressor()

--- a/tests/safeds/ml/regression/_random_forest/test_predict.py
+++ b/tests/safeds/ml/regression/_random_forest/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import RandomForest as RandomForestRegressor
+from tests.fixtures import resolve_resource_path
 
 
 def test_random_forest_predict() -> None:
@@ -25,7 +24,9 @@ def test_random_forest_predict_not_fitted() -> None:
 
 def test_random_forest_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_random_forest.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_random_forest_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_random_forest_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     random_forest = RandomForestRegressor()

--- a/tests/safeds/ml/regression/_ridge_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_ridge_regression/test_fit.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import RidgeRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_ridge_regression_fit() -> None:

--- a/tests/safeds/ml/regression/_ridge_regression/test_fit.py
+++ b/tests/safeds/ml/regression/_ridge_regression/test_fit.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError
 from safeds.ml.regression import RidgeRegression
 
 
 def test_ridge_regression_fit() -> None:
-    table = Table.from_csv("tests/resources/test_ridge_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_ridge_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     ridge_regression = RidgeRegression()
     ridge_regression.fit(tagged_table)
@@ -13,7 +15,7 @@ def test_ridge_regression_fit() -> None:
 
 
 def test_ridge_regression_fit_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_ridge_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_ridge_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     ridge_regression = RidgeRegression()
     with pytest.raises(LearningError):

--- a/tests/safeds/ml/regression/_ridge_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_ridge_regression/test_predict.py
@@ -1,11 +1,13 @@
 import pytest
+
+from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import RidgeRegression
 
 
 def test_ridge_regression_predict() -> None:
-    table = Table.from_csv("tests/resources/test_ridge_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_ridge_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     ridge_regression = RidgeRegression()
     ridge_regression.fit(tagged_table)
@@ -14,7 +16,7 @@ def test_ridge_regression_predict() -> None:
 
 
 def test_ridge_regression_predict_not_fitted() -> None:
-    table = Table.from_csv("tests/resources/test_ridge_regression.csv")
+    table = Table.from_csv(resolve_resource_path("test_ridge_regression.csv"))
     tagged_table = TaggedTable(table, "T")
     ridge_regression = RidgeRegression()
     with pytest.raises(PredictionError):
@@ -22,8 +24,8 @@ def test_ridge_regression_predict_not_fitted() -> None:
 
 
 def test_ridge_regression_predict_invalid() -> None:
-    table = Table.from_csv("tests/resources/test_ridge_regression.csv")
-    invalid_table = Table.from_csv("tests/resources/test_ridge_regression_invalid.csv")
+    table = Table.from_csv(resolve_resource_path("test_ridge_regression.csv"))
+    invalid_table = Table.from_csv(resolve_resource_path("test_ridge_regression_invalid.csv"))
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     ridge_regression = RidgeRegression()

--- a/tests/safeds/ml/regression/_ridge_regression/test_predict.py
+++ b/tests/safeds/ml/regression/_ridge_regression/test_predict.py
@@ -1,9 +1,8 @@
 import pytest
-
-from tests.fixtures import resolve_resource_path
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import PredictionError
 from safeds.ml.regression import RidgeRegression
+from tests.fixtures import resolve_resource_path
 
 
 def test_ridge_regression_predict() -> None:
@@ -25,7 +24,9 @@ def test_ridge_regression_predict_not_fitted() -> None:
 
 def test_ridge_regression_predict_invalid() -> None:
     table = Table.from_csv(resolve_resource_path("test_ridge_regression.csv"))
-    invalid_table = Table.from_csv(resolve_resource_path("test_ridge_regression_invalid.csv"))
+    invalid_table = Table.from_csv(
+        resolve_resource_path("test_ridge_regression_invalid.csv")
+    )
     tagged_table = TaggedTable(table, "T")
     invalid_tagged_table = TaggedTable(invalid_table, "T")
     ridge_regression = RidgeRegression()


### PR DESCRIPTION
Closes #57.

### Summary of Changes

`pytest` can now be launched in any subdirectory of the `tests` folder and tests still work. When we access test data in the `tests/resources` folder, we should now always use the new function `resolve_resource_path` to get an absolute path to a resource, which is thus independent of the working directory.