### PR TITLE
feat: remove `target_name` parameter of `predict`

### DIFF
--- a/src/safeds/ml/classification/_ada_boost.py
+++ b/src/safeds/ml/classification/_ada_boost.py
@@ -1,8 +1,8 @@
-from sklearn.ensemble import AdaBoostClassifier as sk_AdaBoostClassifier
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable
+from sklearn.ensemble import AdaBoostClassifier as sk_AdaBoostClassifier
+
 from ._classifier import Classifier
 
 

--- a/src/safeds/ml/classification/_ada_boost.py
+++ b/src/safeds/ml/classification/_ada_boost.py
@@ -37,7 +37,7 @@ class AdaBoost(Classifier):
             self._classification, tagged_table
         )
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -45,8 +45,6 @@ class AdaBoost(Classifier):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -61,5 +59,5 @@ class AdaBoost(Classifier):
         return safeds.ml._util_sklearn.predict(
             self._classification,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/classification/_ada_boost.py
+++ b/src/safeds/ml/classification/_ada_boost.py
@@ -1,10 +1,8 @@
-from typing import Optional
+from sklearn.ensemble import AdaBoostClassifier as sk_AdaBoostClassifier
 
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable
-from sklearn.ensemble import AdaBoostClassifier as sk_AdaBoostClassifier
-
 from ._classifier import Classifier
 
 

--- a/src/safeds/ml/classification/_classifier.py
+++ b/src/safeds/ml/classification/_classifier.py
@@ -22,7 +22,7 @@ class Classifier(ABC):
         """
 
     @abstractmethod
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -30,8 +30,6 @@ class Classifier(ABC):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------

--- a/src/safeds/ml/classification/_classifier.py
+++ b/src/safeds/ml/classification/_classifier.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from safeds.data.tabular.containers import Table, TaggedTable
 

--- a/src/safeds/ml/classification/_decision_tree.py
+++ b/src/safeds/ml/classification/_decision_tree.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/classification/_decision_tree.py
+++ b/src/safeds/ml/classification/_decision_tree.py
@@ -37,7 +37,7 @@ class DecisionTree(Classifier):
             self._classification, tagged_table
         )
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -45,8 +45,6 @@ class DecisionTree(Classifier):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -61,5 +59,5 @@ class DecisionTree(Classifier):
         return safeds.ml._util_sklearn.predict(
             self._classification,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/classification/_gradient_boosting_classification.py
+++ b/src/safeds/ml/classification/_gradient_boosting_classification.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/classification/_gradient_boosting_classification.py
+++ b/src/safeds/ml/classification/_gradient_boosting_classification.py
@@ -38,7 +38,7 @@ class GradientBoosting(Classifier):
         )
 
     # noinspection PyProtectedMember
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -46,8 +46,6 @@ class GradientBoosting(Classifier):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -62,5 +60,5 @@ class GradientBoosting(Classifier):
         return safeds.ml._util_sklearn.predict(
             self._classification,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/classification/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classification/_k_nearest_neighbors.py
@@ -41,7 +41,7 @@ class KNearestNeighbors(Classifier):
             self._classification, tagged_table
         )
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first
 
@@ -49,8 +49,6 @@ class KNearestNeighbors(Classifier):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -65,5 +63,5 @@ class KNearestNeighbors(Classifier):
         return safeds.ml._util_sklearn.predict(
             self._classification,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/classification/_k_nearest_neighbors.py
+++ b/src/safeds/ml/classification/_k_nearest_neighbors.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/classification/_logistic_regression.py
+++ b/src/safeds/ml/classification/_logistic_regression.py
@@ -37,7 +37,7 @@ class LogisticRegression(Classifier):
             self._classification, tagged_table
         )
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -45,8 +45,6 @@ class LogisticRegression(Classifier):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -61,5 +59,5 @@ class LogisticRegression(Classifier):
         return safeds.ml._util_sklearn.predict(
             self._classification,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/classification/_logistic_regression.py
+++ b/src/safeds/ml/classification/_logistic_regression.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/classification/_random_forest.py
+++ b/src/safeds/ml/classification/_random_forest.py
@@ -36,7 +36,7 @@ class RandomForest(Classifier):
             self._classification, tagged_table
         )
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -44,8 +44,6 @@ class RandomForest(Classifier):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -60,5 +58,5 @@ class RandomForest(Classifier):
         return safeds.ml._util_sklearn.predict(
             self._classification,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/classification/_random_forest.py
+++ b/src/safeds/ml/classification/_random_forest.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_ada_boost.py
+++ b/src/safeds/ml/regression/_ada_boost.py
@@ -35,7 +35,7 @@ class AdaBoost(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -43,8 +43,6 @@ class AdaBoost(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -59,5 +57,5 @@ class AdaBoost(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_ada_boost.py
+++ b/src/safeds/ml/regression/_ada_boost.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_decision_tree.py
+++ b/src/safeds/ml/regression/_decision_tree.py
@@ -35,7 +35,7 @@ class DecisionTree(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -43,8 +43,6 @@ class DecisionTree(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name:  Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -59,5 +57,5 @@ class DecisionTree(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_decision_tree.py
+++ b/src/safeds/ml/regression/_decision_tree.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_elastic_net_regression.py
+++ b/src/safeds/ml/regression/_elastic_net_regression.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_elastic_net_regression.py
+++ b/src/safeds/ml/regression/_elastic_net_regression.py
@@ -35,7 +35,7 @@ class ElasticNetRegression(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -43,8 +43,6 @@ class ElasticNetRegression(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name: Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -59,5 +57,5 @@ class ElasticNetRegression(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_gradient_boosting_regression.py
+++ b/src/safeds/ml/regression/_gradient_boosting_regression.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_gradient_boosting_regression.py
+++ b/src/safeds/ml/regression/_gradient_boosting_regression.py
@@ -37,7 +37,7 @@ class GradientBoosting(Regressor):
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
     # noinspection PyProtectedMember
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -45,8 +45,6 @@ class GradientBoosting(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -61,5 +59,5 @@ class GradientBoosting(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_k_nearest_neighbors.py
+++ b/src/safeds/ml/regression/_k_nearest_neighbors.py
@@ -39,7 +39,7 @@ class KNearestNeighbors(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -47,8 +47,6 @@ class KNearestNeighbors(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name: Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -63,5 +61,5 @@ class KNearestNeighbors(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_k_nearest_neighbors.py
+++ b/src/safeds/ml/regression/_k_nearest_neighbors.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_lasso_regression.py
+++ b/src/safeds/ml/regression/_lasso_regression.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_lasso_regression.py
+++ b/src/safeds/ml/regression/_lasso_regression.py
@@ -35,7 +35,7 @@ class LassoRegression(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -43,8 +43,6 @@ class LassoRegression(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name: Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -59,5 +57,5 @@ class LassoRegression(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_linear_regression.py
+++ b/src/safeds/ml/regression/_linear_regression.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_linear_regression.py
+++ b/src/safeds/ml/regression/_linear_regression.py
@@ -35,7 +35,7 @@ class LinearRegression(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -43,8 +43,6 @@ class LinearRegression(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name: Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -59,5 +57,5 @@ class LinearRegression(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_random_forest.py
+++ b/src/safeds/ml/regression/_random_forest.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable

--- a/src/safeds/ml/regression/_random_forest.py
+++ b/src/safeds/ml/regression/_random_forest.py
@@ -34,7 +34,7 @@ class RandomForest(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -42,8 +42,6 @@ class RandomForest(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------
@@ -58,5 +56,5 @@ class RandomForest(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_regressor.py
+++ b/src/safeds/ml/regression/_regressor.py
@@ -22,7 +22,7 @@ class Regressor(ABC):
         """
 
     @abstractmethod
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -30,8 +30,6 @@ class Regressor(ABC):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name: Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default.
 
         Returns
         -------

--- a/src/safeds/ml/regression/_regressor.py
+++ b/src/safeds/ml/regression/_regressor.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from safeds.data.tabular.containers import Table, TaggedTable
 

--- a/src/safeds/ml/regression/_ridge_regression.py
+++ b/src/safeds/ml/regression/_ridge_regression.py
@@ -35,7 +35,7 @@ class RidgeRegression(Regressor):
         """
         self.target_name = safeds.ml._util_sklearn.fit(self._regression, tagged_table)
 
-    def predict(self, dataset: Table, target_name: Optional[str] = None) -> Table:
+    def predict(self, dataset: Table) -> Table:
         """
         Predict a target vector using a dataset containing feature vectors. The model has to be trained first.
 
@@ -43,8 +43,6 @@ class RidgeRegression(Regressor):
         ----------
         dataset : Table
             The dataset containing the feature vectors.
-        target_name : Optional[str]
-            The name of the target vector. The name of the target column inferred from fit is used by default
 
         Returns
         -------
@@ -59,5 +57,5 @@ class RidgeRegression(Regressor):
         return safeds.ml._util_sklearn.predict(
             self._regression,
             dataset,
-            target_name if target_name is not None else self.target_name,
+            self.target_name,
         )

--- a/src/safeds/ml/regression/_ridge_regression.py
+++ b/src/safeds/ml/regression/_ridge_regression.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 # noinspection PyProtectedMember
 import safeds.ml._util_sklearn
 from safeds.data.tabular.containers import Table, TaggedTable


### PR DESCRIPTION
### Summary of Changes

This can also be accomplished by renaming columns in the returned table. If the input table already contains the column we want to predict, it's an indicator for #9, so we shouldn't just let people change the name here.