### PR TITLE
feat: optionally pass type to column

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -27,7 +27,7 @@ class Column:
         The data.
     name : str
         The name of the column.
-    type : Optional[ColumnType]
+    type_ : Optional[ColumnType]
         The type of the column. If not specified, the type will be inferred from the data.
     """
 
@@ -35,11 +35,11 @@ class Column:
         self,
         data: Iterable,
         name: str,
-        type: Optional[ColumnType] = None,
+        type_: Optional[ColumnType] = None,
     ) -> None:
         self._data: pd.Series = data if isinstance(data, pd.Series) else pd.Series(data)
         self._name: str = name
-        self._type: ColumnType = type if type is not None else ColumnType.from_numpy_dtype(self._data.dtype)
+        self._type: ColumnType = type_ if type_ is not None else ColumnType.from_numpy_dtype(self._data.dtype)
 
     @property
     def name(self) -> str:

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -154,7 +154,7 @@ class Column:
         column : Column
             A new column with the new name.
         """
-        return Column(self._data, new_name)
+        return Column(self._data, new_name, self._type)
 
     def all(self, predicate: Callable[[Any], bool]) -> bool:
         """

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-import typing
 from numbers import Number
 from typing import Any, Callable, Iterator
+from typing import Iterable, Optional
 
 import numpy as np
 import pandas as pd
 from IPython.core.display_functions import DisplayHandle, display
+
 from safeds.data.tabular.typing import ColumnType
 from safeds.exceptions import (
     ColumnLengthMismatchError,
@@ -17,10 +18,28 @@ from safeds.exceptions import (
 
 
 class Column:
-    def __init__(self, data: typing.Iterable, name: str) -> None:
+    """
+    A column of data.
+
+    Parameters
+    ----------
+    data : Iterable
+        The data.
+    name : str
+        The name of the column.
+    type : Optional[ColumnType]
+        The type of the column. If not specified, the type will be inferred from the data.
+    """
+
+    def __init__(
+        self,
+        data: Iterable,
+        name: str,
+        type: Optional[ColumnType] = None,
+    ) -> None:
         self._data: pd.Series = data if isinstance(data, pd.Series) else pd.Series(data)
         self._name: str = name
-        self._type: ColumnType = ColumnType.from_numpy_dtype(self._data.dtype)
+        self._type: ColumnType = type if type is not None else ColumnType.from_numpy_dtype(self._data.dtype)
 
     @property
     def name(self) -> str:
@@ -221,7 +240,7 @@ class Column:
         """
         return self.any(
             lambda value: value is None
-            or (isinstance(value, Number) and np.isnan(value))
+                          or (isinstance(value, Number) and np.isnan(value))
         )
 
     def correlation_with(self, other_column: Column) -> float:
@@ -250,7 +269,7 @@ class Column:
             )
         return self._data.corr(other_column._data)
 
-    def get_unique_values(self) -> list[typing.Any]:
+    def get_unique_values(self) -> list[Any]:
         """
         Return a list of all unique values in the column.
 

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from numbers import Number
-from typing import Any, Callable, Iterator
-from typing import Iterable, Optional
+from typing import Any, Callable, Iterable, Iterator, Optional
 
 import numpy as np
 import pandas as pd
 from IPython.core.display_functions import DisplayHandle, display
-
 from safeds.data.tabular.typing import ColumnType
 from safeds.exceptions import (
     ColumnLengthMismatchError,
@@ -39,7 +37,11 @@ class Column:
     ) -> None:
         self._data: pd.Series = data if isinstance(data, pd.Series) else pd.Series(data)
         self._name: str = name
-        self._type: ColumnType = type_ if type_ is not None else ColumnType.from_numpy_dtype(self._data.dtype)
+        self._type: ColumnType = (
+            type_
+            if type_ is not None
+            else ColumnType.from_numpy_dtype(self._data.dtype)
+        )
 
     @property
     def name(self) -> str:
@@ -240,7 +242,7 @@ class Column:
         """
         return self.any(
             lambda value: value is None
-                          or (isinstance(value, Number) and np.isnan(value))
+            or (isinstance(value, Number) and np.isnan(value))
         )
 
     def correlation_with(self, other_column: Column) -> float:

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -313,8 +313,8 @@ class Table:
                     :, [self.schema._get_column_index_by_name(column_name)]
                 ].squeeze(),
                 column_name,
+                self.schema.get_type_of_column(column_name)
             )
-            output_column._type = self.schema.get_type_of_column(column_name)
             return output_column
 
         raise UnknownColumnNameError([column_name])

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -313,7 +313,7 @@ class Table:
                     :, [self.schema._get_column_index_by_name(column_name)]
                 ].squeeze(),
                 column_name,
-                self.schema.get_type_of_column(column_name)
+                self.schema.get_type_of_column(column_name),
             )
             return output_column
 


### PR DESCRIPTION
Closes #78.

### Summary of Changes

For the sake of consistency it is now possible to pass the type of a `Column` in the constructor. This also improves performance, for example when we call `get_column` on a `Table`. In that case we already know the type of the column anyway, so there's no reason to infer it again.