### PR TITLE
feat: function to drop columns/rows with missing values

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -272,7 +272,7 @@ class Table:
         if self._schema.has_column(column_name):
             output_column = Column(
                 self._data.iloc[
-                    :, [self._schema._get_column_index_by_name(column_name)]
+                :, [self._schema._get_column_index_by_name(column_name)]
                 ].squeeze(),
                 column_name,
                 self._schema.get_type_of_column(column_name),
@@ -573,6 +573,21 @@ class Table:
         )
         return Table(transformed_data)
 
+    def drop_columns_with_missing_values(self) -> Table:
+        """
+        Return a table without the columns that contain missing values.
+
+        Returns
+        -------
+        table : Table
+            A table without the columns that contain missing values.
+        """
+        return Table.from_columns([
+            column
+            for column in self.to_columns()
+            if not column.has_missing_values()
+        ])
+
     def drop_columns_with_non_numerical_values(self) -> Table:
         """
         Return a table without the columns that contain non-numerical values.
@@ -593,11 +608,23 @@ class Table:
         -------
         result : Table
             The table with the duplicate rows removed.
-
         """
         df = self._data.drop_duplicates(ignore_index=True)
         df.columns = self._schema.get_column_names()
         return Table(df)
+
+    def drop_rows_with_missing_values(self) -> Table:
+        """
+        Return a table without the rows that contain missing values.
+
+        Returns
+        -------
+        table : Table
+            A table without the rows that contain missing values.
+        """
+        result = self._data.copy(deep=True)
+        result = result.dropna(axis="index")
+        return Table(result, self._schema)
 
     def drop_rows_with_outliers(self) -> Table:
         """
@@ -828,10 +855,7 @@ class Table:
 
     def sort_columns(
         self,
-        query: Callable[[Column, Column], int] = lambda col1, col2: (
-            col1.name > col2.name
-        )
-        - (col1.name < col2.name),
+        query: Callable[[Column, Column], int] = lambda col1, col2: (col1.name > col2.name) - (col1.name < col2.name),
     ) -> Table:
         """
         Sort a table with the given lambda function.
@@ -868,7 +892,8 @@ class Table:
         Returns
         -------
         result : (Table, Table)
-            A tuple containing the two resulting tables. The first table has the specified size, the second table contains the rest of the data.
+            A tuple containing the two resulting tables. The first table has the specified size, the second table
+            contains the rest of the data.
 
 
         """

--- a/tests/safeds/data/tabular/containers/_table/test_drop_columns_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_drop_columns_with_missing_values.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pandas as pd
+from safeds.data.tabular.containers import Table
+from safeds.data.tabular.typing import ColumnType, TableSchema
+
+
+def test_drop_columns_with_missing_values_valid() -> None:
+    table = Table(
+        pd.DataFrame(
+            data={
+                "col1": [None, None, None, None],
+                "col2": [1, 2, 3, None],
+                "col3": [1, 2, 3, 4],
+                "col4": [2, 3, 1, 4],
+            }
+        )
+    )
+    updated_table = table.drop_columns_with_missing_values()
+    assert updated_table.get_column_names() == ["col3", "col4"]
+
+
+def test_drop_columns_with_missing_values_empty() -> None:
+    table = Table(
+        [], TableSchema({"col1": ColumnType.from_numpy_dtype(np.dtype(float))})
+    )
+    updated_table = table.drop_columns_with_missing_values()
+    assert updated_table.get_column_names() == ["col1"]

--- a/tests/safeds/data/tabular/containers/_table/test_drop_rows_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_drop_rows_with_missing_values.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pandas as pd
+from safeds.data.tabular.containers import Table
+from safeds.data.tabular.typing import ColumnType, TableSchema
+
+
+def test_drop_rows_with_missing_values_valid() -> None:
+    table = Table(
+        pd.DataFrame(
+            data={
+                "col1": [None, None, "C", "A"],
+                "col2": [None, "Test1", "Test3", "Test1"],
+                "col3": [None, 2, 3, 4],
+                "col4": [None, 3, 1, 4],
+            }
+        )
+    )
+    updated_table = table.drop_rows_with_missing_values()
+    assert updated_table.count_rows() == 2
+
+
+def test_drop_rows_with_missing_values_empty() -> None:
+    table = Table(
+        [], TableSchema({"col1": ColumnType.from_numpy_dtype(np.dtype(float))})
+    )
+    updated_table = table.drop_rows_with_missing_values()
+    assert updated_table.get_column_names() == ["col1"]


### PR DESCRIPTION
Closes #10.

### Summary of Changes

Add methods to `Table` to handle missing values:
* `drop_columns_with_missing_values` returns a `Table` without the columns that have missing values.
* `drop_rows_with_missing_values` returns a `Table`  without the rows that have missing values.
