### PR TITLE
feat: rename `keep_columns` to `keep_only_columns`

### DIFF
--- a/docs/tutorials/data_processing.ipynb
+++ b/docs/tutorials/data_processing.ipynb
@@ -184,7 +184,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "titanic_slice.keep_columns([\"name\", \"survived\"])"
+    "titanic_slice.keep_only_columns([\"name\", \"survived\"])"
    ],
    "metadata": {
     "collapsed": false

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -670,7 +670,7 @@ class Table:
             result_table = self.from_rows(rows)
         return result_table
 
-    def keep_columns(self, column_names: list[str]) -> Table:
+    def keep_only_columns(self, column_names: list[str]) -> Table:
         """
         Return a table with only the given column(s).
 

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -50,7 +50,7 @@ class LabelEncoder:
             If the model fitting was unsuccessful.
         """
         try:
-            self._le.fit(table.keep_columns([column])._data)
+            self._le.fit(table.keep_only_columns([column])._data)
         except exceptions.NotFittedError as exc:
             raise LearningError("") from exc
 

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -30,7 +30,7 @@ class OneHotEncoder:
             If there was an error during fitting.
         """
         try:
-            table_k_columns = table.keep_columns(column_names=columns)
+            table_k_columns = table.keep_only_columns(column_names=columns)
             df = table_k_columns._data
             df.columns = table_k_columns.schema.get_column_names()
             self._encoder.fit(df)
@@ -57,7 +57,7 @@ class OneHotEncoder:
             If the encoder wasn't fitted before transforming.
         """
         try:
-            table_k_columns = table.keep_columns(self._encoder.feature_names_in_)
+            table_k_columns = table.keep_only_columns(self._encoder.feature_names_in_)
             df_k_columns = table_k_columns._data
             df_k_columns.columns = table_k_columns.schema.get_column_names()
             df_new = pd.DataFrame(self._encoder.transform(df_k_columns).toarray())
@@ -113,7 +113,7 @@ class OneHotEncoder:
         """
         try:
             data = self._encoder.inverse_transform(
-                table.keep_columns(self._encoder.get_feature_names_out())._data
+                table.keep_only_columns(self._encoder.get_feature_names_out())._data
             )
             df = pd.DataFrame(data)
             df.columns = self._encoder.feature_names_in_

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -4,15 +4,15 @@ from safeds.exceptions import UnknownColumnNameError
 from tests.fixtures import resolve_resource_path
 
 
-def test_table_column_keep() -> None:
+def test_keep_columns() -> None:
     table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
-    transformed_table = table.keep_columns(["A"])
+    transformed_table = table.keep_only_columns(["A"])
     assert transformed_table.schema.has_column(
         "A"
     ) and not transformed_table.schema.has_column("B")
 
 
-def test_table_column_keep_warning() -> None:
+def test_keep_columns_warning() -> None:
     table = Table.from_csv(resolve_resource_path("test_table_read_csv.csv"))
     with pytest.raises(UnknownColumnNameError):
-        table.keep_columns(["C"])
+        table.keep_only_columns(["C"])


### PR DESCRIPTION
### Summary of Changes

In `Table`, rename `keep_columns` to `keep_only_columns` to better match the semantics of the method.
