### PR TITLE
test: better tests for `predict` method of models

### DIFF
--- a/tests/safeds/ml/classification/test_ada_boost.py
+++ b/tests/safeds/ml/classification/test_ada_boost.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import AdaBoost, Classifier
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/classification/test_ada_boost.py
+++ b/tests/safeds/ml/classification/test_ada_boost.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import AdaBoost, Classifier
 from tests.fixtures import resolve_resource_path
@@ -37,21 +37,25 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)
-        fitted_classifier.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.features == valid_data.features
 
-    def test_should_raise_when_not_fitted(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
+        fitted_classifier = classifier.fit(valid_data)
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.target.name == "T"
+
+    def test_should_raise_when_not_fitted(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             classifier.predict(valid_data.features)
 
     def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, valid_data: TaggedTable, invalid_data: TaggedTable
+        self,
+        classifier: Classifier,
+        valid_data: TaggedTable,
+        invalid_data: TaggedTable
     ) -> None:
         fitted_classifier = classifier.fit(valid_data)
         with pytest.raises(PredictionError):

--- a/tests/safeds/ml/classification/test_ada_boost.py
+++ b/tests/safeds/ml/classification/test_ada_boost.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import AdaBoost, Classifier
@@ -24,15 +23,11 @@ def invalid_data() -> TaggedTable:
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         classifier.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, classifier: Classifier, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             classifier.fit(invalid_data)
 
@@ -53,10 +48,7 @@ class TestPredict:
             classifier.predict(valid_data.features)
 
     def test_should_raise_on_invalid_data(
-        self,
-        classifier: Classifier,
-        valid_data: TaggedTable,
-        invalid_data: TaggedTable
+        self, classifier: Classifier, valid_data: TaggedTable, invalid_data: TaggedTable
     ) -> None:
         fitted_classifier = classifier.fit(valid_data)
         with pytest.raises(PredictionError):

--- a/tests/safeds/ml/classification/test_classifier.py
+++ b/tests/safeds/ml/classification/test_classifier.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+
 from safeds.data.tabular.containers import Column, Table, TaggedTable
 from safeds.ml.classification import Classifier
 

--- a/tests/safeds/ml/classification/test_classifier.py
+++ b/tests/safeds/ml/classification/test_classifier.py
@@ -19,6 +19,7 @@ class DummyClassifier(Classifier):
     """
 
     def fit(self, training_set: TaggedTable) -> DummyClassifier:
+        # pylint: disable=unused-argument
         return self
 
     def predict(self, dataset: Table) -> TaggedTable:

--- a/tests/safeds/ml/classification/test_classifier.py
+++ b/tests/safeds/ml/classification/test_classifier.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pandas as pd
-
 from safeds.data.tabular.containers import Column, Table, TaggedTable
 from safeds.ml.classification import Classifier
 

--- a/tests/safeds/ml/classification/test_decision_tree.py
+++ b/tests/safeds/ml/classification/test_decision_tree.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, DecisionTree
@@ -24,15 +23,11 @@ def invalid_data() -> TaggedTable:
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         classifier.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, classifier: Classifier, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             classifier.fit(invalid_data)
 
@@ -48,9 +43,7 @@ class TestPredict:
         prediction = fitted_classifier.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             classifier.predict(valid_data.features)
 

--- a/tests/safeds/ml/classification/test_decision_tree.py
+++ b/tests/safeds/ml/classification/test_decision_tree.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, DecisionTree
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/classification/test_decision_tree.py
+++ b/tests/safeds/ml/classification/test_decision_tree.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, DecisionTree
 from tests.fixtures import resolve_resource_path
@@ -37,12 +37,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)
-        fitted_classifier.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
+        fitted_classifier = classifier.fit(valid_data)
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, classifier: Classifier, valid_data: TaggedTable

--- a/tests/safeds/ml/classification/test_gradient_boosting.py
+++ b/tests/safeds/ml/classification/test_gradient_boosting.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, GradientBoosting
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/classification/test_gradient_boosting.py
+++ b/tests/safeds/ml/classification/test_gradient_boosting.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, GradientBoosting
@@ -13,30 +12,22 @@ def classifier() -> Classifier:
 
 @pytest.fixture()
 def valid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_gradient_boosting_classification.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_gradient_boosting_classification.csv"))
     return TaggedTable(table, "T")
 
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_gradient_boosting_classification_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_gradient_boosting_classification_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         classifier.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, classifier: Classifier, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             classifier.fit(invalid_data)
 
@@ -52,9 +43,7 @@ class TestPredict:
         prediction = fitted_classifier.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             classifier.predict(valid_data.features)
 

--- a/tests/safeds/ml/classification/test_gradient_boosting.py
+++ b/tests/safeds/ml/classification/test_gradient_boosting.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, GradientBoosting
 from tests.fixtures import resolve_resource_path
@@ -41,12 +41,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)
-        fitted_classifier.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
+        fitted_classifier = classifier.fit(valid_data)
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, classifier: Classifier, valid_data: TaggedTable

--- a/tests/safeds/ml/classification/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/classification/test_k_nearest_neighbors.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, KNearestNeighbors
 from tests.fixtures import resolve_resource_path
@@ -39,12 +39,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)
-        fitted_classifier.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
+        fitted_classifier = classifier.fit(valid_data)
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, classifier: Classifier, valid_data: TaggedTable

--- a/tests/safeds/ml/classification/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/classification/test_k_nearest_neighbors.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, KNearestNeighbors
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/classification/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/classification/test_k_nearest_neighbors.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, KNearestNeighbors
@@ -19,22 +18,16 @@ def valid_data() -> TaggedTable:
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_k_nearest_neighbors_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_k_nearest_neighbors_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         classifier.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, classifier: Classifier, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             classifier.fit(invalid_data)
 
@@ -50,9 +43,7 @@ class TestPredict:
         prediction = fitted_classifier.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             classifier.predict(valid_data.features)
 

--- a/tests/safeds/ml/classification/test_logistic_regression.py
+++ b/tests/safeds/ml/classification/test_logistic_regression.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, LogisticRegression
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/classification/test_logistic_regression.py
+++ b/tests/safeds/ml/classification/test_logistic_regression.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, LogisticRegression
 from tests.fixtures import resolve_resource_path
@@ -39,12 +39,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)
-        fitted_classifier.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
+        fitted_classifier = classifier.fit(valid_data)
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, classifier: Classifier, valid_data: TaggedTable

--- a/tests/safeds/ml/classification/test_logistic_regression.py
+++ b/tests/safeds/ml/classification/test_logistic_regression.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, LogisticRegression
@@ -19,22 +18,16 @@ def valid_data() -> TaggedTable:
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_logistic_regression_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_logistic_regression_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         classifier.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, classifier: Classifier, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             classifier.fit(invalid_data)
 
@@ -50,9 +43,7 @@ class TestPredict:
         prediction = fitted_classifier.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             classifier.predict(valid_data.features)
 

--- a/tests/safeds/ml/classification/test_random_forest.py
+++ b/tests/safeds/ml/classification/test_random_forest.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, RandomForest
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/classification/test_random_forest.py
+++ b/tests/safeds/ml/classification/test_random_forest.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, RandomForest
 from tests.fixtures import resolve_resource_path
@@ -37,12 +37,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)
-        fitted_classifier.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
+        fitted_classifier = classifier.fit(valid_data)
+        prediction = fitted_classifier.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, classifier: Classifier, valid_data: TaggedTable

--- a/tests/safeds/ml/classification/test_random_forest.py
+++ b/tests/safeds/ml/classification/test_random_forest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.classification import Classifier, RandomForest
@@ -24,15 +23,11 @@ def invalid_data() -> TaggedTable:
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         classifier.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, classifier: Classifier, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, classifier: Classifier, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             classifier.fit(invalid_data)
 
@@ -48,9 +43,7 @@ class TestPredict:
         prediction = fitted_classifier.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, classifier: Classifier, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             classifier.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_ada_boost.py
+++ b/tests/safeds/ml/regression/test_ada_boost.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import AdaBoost, Regressor
@@ -24,15 +23,11 @@ def invalid_data() -> TaggedTable:
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -48,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_ada_boost.py
+++ b/tests/safeds/ml/regression/test_ada_boost.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import AdaBoost, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_ada_boost.py
+++ b/tests/safeds/ml/regression/test_ada_boost.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import AdaBoost, Regressor
 from tests.fixtures import resolve_resource_path
@@ -37,12 +37,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_decision_tree.py
+++ b/tests/safeds/ml/regression/test_decision_tree.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import DecisionTree, Regressor
@@ -24,15 +23,11 @@ def invalid_data() -> TaggedTable:
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -48,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_decision_tree.py
+++ b/tests/safeds/ml/regression/test_decision_tree.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import DecisionTree, Regressor
 from tests.fixtures import resolve_resource_path
@@ -37,12 +37,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_decision_tree.py
+++ b/tests/safeds/ml/regression/test_decision_tree.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import DecisionTree, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_elastic_net.py
+++ b/tests/safeds/ml/regression/test_elastic_net.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import ElasticNetRegression, Regressor
 from tests.fixtures import resolve_resource_path
@@ -41,12 +41,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_elastic_net.py
+++ b/tests/safeds/ml/regression/test_elastic_net.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import ElasticNetRegression, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_elastic_net.py
+++ b/tests/safeds/ml/regression/test_elastic_net.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import ElasticNetRegression, Regressor
@@ -13,30 +12,22 @@ def regressor() -> Regressor:
 
 @pytest.fixture()
 def valid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_elastic_net_regression.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_elastic_net_regression.csv"))
     return TaggedTable(table, "T")
 
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_elastic_net_regression_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_elastic_net_regression_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -52,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_gradient_boosting.py
+++ b/tests/safeds/ml/regression/test_gradient_boosting.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import GradientBoosting, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_gradient_boosting.py
+++ b/tests/safeds/ml/regression/test_gradient_boosting.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import GradientBoosting, Regressor
 from tests.fixtures import resolve_resource_path
@@ -41,12 +41,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_gradient_boosting.py
+++ b/tests/safeds/ml/regression/test_gradient_boosting.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import GradientBoosting, Regressor
@@ -13,30 +12,22 @@ def regressor() -> Regressor:
 
 @pytest.fixture()
 def valid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_gradient_boosting_regression.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_gradient_boosting_regression.csv"))
     return TaggedTable(table, "T")
 
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_gradient_boosting_regression_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_gradient_boosting_regression_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -52,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/regression/test_k_nearest_neighbors.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import KNearestNeighbors, Regressor
 from tests.fixtures import resolve_resource_path
@@ -39,12 +39,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/regression/test_k_nearest_neighbors.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import KNearestNeighbors, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/regression/test_k_nearest_neighbors.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import KNearestNeighbors, Regressor
@@ -19,22 +18,16 @@ def valid_data() -> TaggedTable:
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_k_nearest_neighbors_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_k_nearest_neighbors_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -50,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_lasso_regression.py
+++ b/tests/safeds/ml/regression/test_lasso_regression.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import LassoRegression, Regressor
@@ -19,22 +18,16 @@ def valid_data() -> TaggedTable:
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_lasso_regression_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_lasso_regression_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -50,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_lasso_regression.py
+++ b/tests/safeds/ml/regression/test_lasso_regression.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import LassoRegression, Regressor
 from tests.fixtures import resolve_resource_path
@@ -39,12 +39,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_lasso_regression.py
+++ b/tests/safeds/ml/regression/test_lasso_regression.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import LassoRegression, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_linear_regression.py
+++ b/tests/safeds/ml/regression/test_linear_regression.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import LinearRegression, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_linear_regression.py
+++ b/tests/safeds/ml/regression/test_linear_regression.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import LinearRegression, Regressor
@@ -19,22 +18,16 @@ def valid_data() -> TaggedTable:
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_linear_regression_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_linear_regression_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -50,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_linear_regression.py
+++ b/tests/safeds/ml/regression/test_linear_regression.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import LinearRegression, Regressor
 from tests.fixtures import resolve_resource_path
@@ -39,12 +39,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_random_forest.py
+++ b/tests/safeds/ml/regression/test_random_forest.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import RandomForest, Regressor
 from tests.fixtures import resolve_resource_path

--- a/tests/safeds/ml/regression/test_random_forest.py
+++ b/tests/safeds/ml/regression/test_random_forest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import RandomForest, Regressor
@@ -24,15 +23,11 @@ def invalid_data() -> TaggedTable:
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -48,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_random_forest.py
+++ b/tests/safeds/ml/regression/test_random_forest.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import RandomForest, Regressor
 from tests.fixtures import resolve_resource_path
@@ -37,12 +37,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_regressor.py
+++ b/tests/safeds/ml/regression/test_regressor.py
@@ -23,6 +23,7 @@ class DummyRegressor(Regressor):
     """
 
     def fit(self, training_set: TaggedTable) -> DummyRegressor:
+        # pylint: disable=unused-argument
         return self
 
     def predict(self, dataset: Table) -> TaggedTable:

--- a/tests/safeds/ml/regression/test_regressor.py
+++ b/tests/safeds/ml/regression/test_regressor.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
-
 from safeds.data.tabular.containers import Column, Table, TaggedTable
 from safeds.exceptions import ColumnLengthMismatchError
 from safeds.ml.regression import Regressor
+
 # noinspection PyProtectedMember
 from safeds.ml.regression._regressor import _check_metrics_preconditions
 
@@ -46,9 +46,7 @@ class TestMeanAbsoluteError:
             ([0.5, 0.5], [1.5, 1.5], 1),
         ],
     )
-    def test_valid_data(
-        self, predicted: list[float], expected: list[float], result: float
-    ) -> None:
+    def test_valid_data(self, predicted: list[float], expected: list[float], result: float) -> None:
         predicted_column = Column("predicted", predicted)
         expected_column = Column("expected", expected)
         table = TaggedTable(
@@ -64,9 +62,7 @@ class TestMeanSquaredError:
         "predicted, expected, result",
         [([1, 2], [1, 2], 0), ([0, 0], [1, 1], 1), ([1, 1, 1], [2, 2, 11], 34)],
     )
-    def test_valid_data(
-        self, predicted: list[float], expected: list[float], result: float
-    ) -> None:
+    def test_valid_data(self, predicted: list[float], expected: list[float], result: float) -> None:
         predicted_column = Column("predicted", predicted)
         expected_column = Column("expected", expected)
         table = TaggedTable(

--- a/tests/safeds/ml/regression/test_regressor.py
+++ b/tests/safeds/ml/regression/test_regressor.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column, Table, TaggedTable
 from safeds.exceptions import ColumnLengthMismatchError
 from safeds.ml.regression import Regressor
-
 # noinspection PyProtectedMember
 from safeds.ml.regression._regressor import _check_metrics_preconditions
 

--- a/tests/safeds/ml/regression/test_ridge_regression.py
+++ b/tests/safeds/ml/regression/test_ridge_regression.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable
+from safeds.data.tabular.containers import Table, TaggedTable, Column
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import Regressor, RidgeRegression
 from tests.fixtures import resolve_resource_path
@@ -39,12 +39,15 @@ class TestFit:
 
 
 class TestPredict:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_include_features_of_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        fitted_regressor.predict(valid_data.features)
-        assert True  # This asserts that the predict method succeeds
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.features == valid_data.features
+
+    def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
+        fitted_regressor = regressor.fit(valid_data)
+        prediction = fitted_regressor.predict(valid_data.features)
+        assert prediction.target.name == "T"
 
     def test_should_raise_when_not_fitted(
         self, regressor: Regressor, valid_data: TaggedTable

--- a/tests/safeds/ml/regression/test_ridge_regression.py
+++ b/tests/safeds/ml/regression/test_ridge_regression.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import Regressor, RidgeRegression
@@ -19,22 +18,16 @@ def valid_data() -> TaggedTable:
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    table = Table.from_csv_file(
-        resolve_resource_path("test_ridge_regression_invalid.csv")
-    )
+    table = Table.from_csv_file(resolve_resource_path("test_ridge_regression_invalid.csv"))
     return TaggedTable(table, "T")
 
 
 class TestFit:
-    def test_should_succeed_on_valid_data(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_succeed_on_valid_data(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         regressor.fit(valid_data)
         assert True  # This asserts that the fit method succeeds
 
-    def test_should_raise_on_invalid_data(
-        self, regressor: Regressor, invalid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_on_invalid_data(self, regressor: Regressor, invalid_data: TaggedTable) -> None:
         with pytest.raises(LearningError):
             regressor.fit(invalid_data)
 
@@ -50,9 +43,7 @@ class TestPredict:
         prediction = fitted_regressor.predict(valid_data.features)
         assert prediction.target.name == "T"
 
-    def test_should_raise_when_not_fitted(
-        self, regressor: Regressor, valid_data: TaggedTable
-    ) -> None:
+    def test_should_raise_when_not_fitted(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         with pytest.raises(PredictionError):
             regressor.predict(valid_data.features)
 

--- a/tests/safeds/ml/regression/test_ridge_regression.py
+++ b/tests/safeds/ml/regression/test_ridge_regression.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Table, TaggedTable, Column
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.exceptions import LearningError, PredictionError
 from safeds.ml.regression import Regressor, RidgeRegression
 from tests.fixtures import resolve_resource_path


### PR DESCRIPTION
Closes #102.

### Summary of Changes

Instead of simply checking that the `predict` method of models does not raise an exception, we now also check that
* the features of the input are preserved in the result
* the target column has the correct name.