### PR TITLE
feat: rename `fit_transform` to `fit_and_transform`

### DIFF
--- a/src/safeds/data/tabular/transformation/_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_table_transformer.py
@@ -52,7 +52,7 @@ class TableTransformer(ABC):
             If the transformer has not been fitted yet.
         """
 
-    def fit_transform(self, table: Table, column_names: Optional[list[str]] = None) -> Table:
+    def fit_and_transform(self, table: Table, column_names: Optional[list[str]] = None) -> Table:
         """
         Learn a transformation for a set of columns in a table and apply the learned transformation to the same table.
         If you also need the fitted transformer, use `fit` and `transform` separately.

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -145,7 +145,7 @@ class TestFitTransform:
     def test_should_return_transformed_table(
         self, table: Table, column_names: Optional[list[str]], strategy: ImputerStrategy, expected: Table
     ) -> None:
-        assert Imputer(strategy).fit_transform(table, column_names) == expected
+        assert Imputer(strategy).fit_and_transform(table, column_names) == expected
 
     def test_should_raise_if_strategy_is_mode_but_multiple_values_are_most_frequent(self) -> None:
         table = Table.from_columns(
@@ -155,7 +155,7 @@ class TestFitTransform:
         )
 
         with pytest.raises(IndexError):
-            Imputer(Imputer.Strategy.Mode()).fit_transform(table)
+            Imputer(Imputer.Strategy.Mode()).fit_and_transform(table)
 
     def test_should_not_change_original_table(self) -> None:
         table = Table.from_columns(
@@ -164,7 +164,7 @@ class TestFitTransform:
             ]
         )
 
-        Imputer(strategy=Imputer.Strategy.Constant(1)).fit_transform(table)
+        Imputer(strategy=Imputer.Strategy.Constant(1)).fit_and_transform(table)
 
         expected = Table.from_columns(
             [

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -63,7 +63,7 @@ class TestTransform:
             transformer.transform(table)
 
 
-class TestFitTransform:
+class TestFitAndTransform:
     @pytest.mark.parametrize(
         ("table", "column_names", "strategy", "expected"),
         [

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -100,7 +100,7 @@ class TestFitTransform:
     def test_should_return_transformed_table(
         self, table: Table, column_names: Optional[list[str]], expected: Table
     ) -> None:
-        assert LabelEncoder().fit_transform(table, column_names) == expected
+        assert LabelEncoder().fit_and_transform(table, column_names) == expected
 
     def test_should_not_change_original_table(self) -> None:
         table = Table.from_columns(
@@ -109,7 +109,7 @@ class TestFitTransform:
             ]
         )
 
-        LabelEncoder().fit_transform(table)
+        LabelEncoder().fit_and_transform(table)
 
         expected = Table.from_columns(
             [

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -63,7 +63,7 @@ class TestTransform:
             transformer.transform(table)
 
 
-class TestFitTransform:
+class TestFitAndTransform:
     @pytest.mark.parametrize(
         ("table", "column_names", "expected"),
         [

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -104,7 +104,7 @@ class TestFitTransform:
     def test_should_return_transformed_table(
         self, table: Table, column_names: Optional[list[str]], expected: Table
     ) -> None:
-        assert OneHotEncoder().fit_transform(table, column_names) == expected
+        assert OneHotEncoder().fit_and_transform(table, column_names) == expected
 
     def test_should_not_change_original_table(self) -> None:
         table = Table.from_columns(
@@ -113,7 +113,7 @@ class TestFitTransform:
             ]
         )
 
-        OneHotEncoder().fit_transform(table)
+        OneHotEncoder().fit_and_transform(table)
 
         expected = Table.from_columns(
             [

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -63,7 +63,7 @@ class TestTransform:
             transformer.transform(table)
 
 
-class TestFitTransform:
+class TestFitAndTransform:
     @pytest.mark.parametrize(
         ("table", "column_names", "expected"),
         [


### PR DESCRIPTION
Closes #112.

### Summary of Changes

Rename `fit_transform` to `fit_and_transform` to better indicate that this method combines the two steps `fit` and `transform`.