### PR TITLE
feat: rename `drop_XY` method to `remove_XY`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -532,108 +532,6 @@ class Table:
         result.columns = self._schema.get_column_names()
         return Table(result)
 
-    def drop_columns(self, column_names: list[str]) -> Table:
-        """
-        Return a table without the given column(s).
-
-        Parameters
-        ----------
-        column_names : list[str]
-            A list containing all columns to be dropped.
-
-        Returns
-        -------
-        table : Table
-            A table without the given columns.
-
-        Raises
-        ------
-        ColumnNameError
-            If any of the given columns do not exist.
-        """
-        invalid_columns = []
-        column_indices = []
-        for name in column_names:
-            if not self._schema.has_column(name):
-                invalid_columns.append(name)
-            else:
-                column_indices.append(self._schema._get_column_index_by_name(name))
-        if len(invalid_columns) != 0:
-            raise UnknownColumnNameError(invalid_columns)
-        transformed_data = self._data.drop(labels=column_indices, axis="columns")
-        transformed_data.columns = list(name for name in self._schema.get_column_names() if name not in column_names)
-        return Table(transformed_data)
-
-    def drop_columns_with_missing_values(self) -> Table:
-        """
-        Return a table without the columns that contain missing values.
-
-        Returns
-        -------
-        table : Table
-            A table without the columns that contain missing values.
-        """
-        return Table.from_columns([column for column in self.to_columns() if not column.has_missing_values()])
-
-    def drop_columns_with_non_numerical_values(self) -> Table:
-        """
-        Return a table without the columns that contain non-numerical values.
-
-        Returns
-        -------
-        table : Table
-            A table without the columns that contain non-numerical values.
-
-        """
-        return Table.from_columns([column for column in self.to_columns() if column.type.is_numeric()])
-
-    def drop_duplicate_rows(self) -> Table:
-        """
-        Return a copy of the table with every duplicate row removed.
-
-        Returns
-        -------
-        result : Table
-            The table with the duplicate rows removed.
-        """
-        df = self._data.drop_duplicates(ignore_index=True)
-        df.columns = self._schema.get_column_names()
-        return Table(df)
-
-    def drop_rows_with_missing_values(self) -> Table:
-        """
-        Return a table without the rows that contain missing values.
-
-        Returns
-        -------
-        table : Table
-            A table without the rows that contain missing values.
-        """
-        result = self._data.copy(deep=True)
-        result = result.dropna(axis="index")
-        return Table(result, self._schema)
-
-    def drop_rows_with_outliers(self) -> Table:
-        """
-        Remove all rows from the table that contain at least one outlier.
-
-        We define an outlier as a value that has a distance of more than 3 standard deviations from the column mean.
-        Missing values are not considered outliers. They are also ignored during the calculation of the standard
-        deviation.
-
-        Returns
-        -------
-        new_table : Table
-            A new table without rows containing outliers.
-        """
-        copy = self._data.copy(deep=True)
-
-        table_without_nonnumericals = self.drop_columns_with_non_numerical_values()
-        z_scores = np.absolute(stats.zscore(table_without_nonnumericals._data, nan_policy="omit"))
-        filter_ = ((z_scores < 3) | np.isnan(z_scores)).all(axis=1)
-
-        return Table(copy[filter_], self._schema)
-
     def filter_rows(self, query: Callable[[Row], bool]) -> Table:
         """
         Return a table with rows filtered by Callable (e.g. lambda function).
@@ -686,6 +584,108 @@ class Table:
         transformed_data = self._data[column_indices]
         transformed_data.columns = list(name for name in self._schema.get_column_names() if name in column_names)
         return Table(transformed_data)
+
+    def remove_columns(self, column_names: list[str]) -> Table:
+        """
+        Return a table without the given column(s).
+
+        Parameters
+        ----------
+        column_names : list[str]
+            A list containing all columns to be dropped.
+
+        Returns
+        -------
+        table : Table
+            A table without the given columns.
+
+        Raises
+        ------
+        ColumnNameError
+            If any of the given columns do not exist.
+        """
+        invalid_columns = []
+        column_indices = []
+        for name in column_names:
+            if not self._schema.has_column(name):
+                invalid_columns.append(name)
+            else:
+                column_indices.append(self._schema._get_column_index_by_name(name))
+        if len(invalid_columns) != 0:
+            raise UnknownColumnNameError(invalid_columns)
+        transformed_data = self._data.drop(labels=column_indices, axis="columns")
+        transformed_data.columns = list(name for name in self._schema.get_column_names() if name not in column_names)
+        return Table(transformed_data)
+
+    def remove_columns_with_missing_values(self) -> Table:
+        """
+        Return a table without the columns that contain missing values.
+
+        Returns
+        -------
+        table : Table
+            A table without the columns that contain missing values.
+        """
+        return Table.from_columns([column for column in self.to_columns() if not column.has_missing_values()])
+
+    def remove_columns_with_non_numerical_values(self) -> Table:
+        """
+        Return a table without the columns that contain non-numerical values.
+
+        Returns
+        -------
+        table : Table
+            A table without the columns that contain non-numerical values.
+
+        """
+        return Table.from_columns([column for column in self.to_columns() if column.type.is_numeric()])
+
+    def remove_duplicate_rows(self) -> Table:
+        """
+        Return a copy of the table with every duplicate row removed.
+
+        Returns
+        -------
+        result : Table
+            The table with the duplicate rows removed.
+        """
+        df = self._data.drop_duplicates(ignore_index=True)
+        df.columns = self._schema.get_column_names()
+        return Table(df)
+
+    def remove_rows_with_missing_values(self) -> Table:
+        """
+        Return a table without the rows that contain missing values.
+
+        Returns
+        -------
+        table : Table
+            A table without the rows that contain missing values.
+        """
+        result = self._data.copy(deep=True)
+        result = result.dropna(axis="index")
+        return Table(result, self._schema)
+
+    def remove_rows_with_outliers(self) -> Table:
+        """
+        Remove all rows from the table that contain at least one outlier.
+
+        We define an outlier as a value that has a distance of more than 3 standard deviations from the column mean.
+        Missing values are not considered outliers. They are also ignored during the calculation of the standard
+        deviation.
+
+        Returns
+        -------
+        new_table : Table
+            A new table without rows containing outliers.
+        """
+        copy = self._data.copy(deep=True)
+
+        table_without_nonnumericals = self.remove_columns_with_non_numerical_values()
+        z_scores = np.absolute(stats.zscore(table_without_nonnumericals._data, nan_policy="omit"))
+        filter_ = ((z_scores < 3) | np.isnan(z_scores)).all(axis=1)
+
+        return Table(copy[filter_], self._schema)
 
     def rename_column(self, old_name: str, new_name: str) -> Table:
         """
@@ -828,7 +828,7 @@ class Table:
     def sort_columns(
         self,
         comparator: Callable[[Column, Column], int] = lambda col1, col2: (col1.name > col2.name)
-        - (col1.name < col2.name),
+                                                                         - (col1.name < col2.name),
     ) -> Table:
         """
         Sort the columns of a `Table` with the given comparator and return a new `Table`. The original table is not
@@ -955,7 +955,7 @@ class Table:
         """
         Plot a correlation heatmap for all numerical columns of this `Table`.
         """
-        only_numerical = self.drop_columns_with_non_numerical_values()
+        only_numerical = self.remove_columns_with_non_numerical_values()
 
         sns.heatmap(
             data=only_numerical._data.corr(),

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns.py
@@ -4,13 +4,13 @@ from safeds.exceptions import UnknownColumnNameError
 from tests.helpers import resolve_resource_path
 
 
-def test_table_column_drop() -> None:
+def test_table_remove_columns() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
-    transformed_table = table.drop_columns(["A"])
+    transformed_table = table.remove_columns(["A"])
     assert transformed_table.schema.has_column("B") and not transformed_table.schema.has_column("A")
 
 
-def test_table_column_drop_warning() -> None:
+def test_table_remove_columns_warning() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
     with pytest.raises(UnknownColumnNameError):
-        table.drop_columns(["C"])
+        table.remove_columns(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
@@ -4,7 +4,7 @@ from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import ColumnType, TableSchema
 
 
-def test_drop_columns_with_missing_values_valid() -> None:
+def test_remove_columns_with_missing_values_valid() -> None:
     table = Table(
         pd.DataFrame(
             data={
@@ -15,13 +15,13 @@ def test_drop_columns_with_missing_values_valid() -> None:
             }
         )
     )
-    updated_table = table.drop_columns_with_missing_values()
+    updated_table = table.remove_columns_with_missing_values()
     assert updated_table.get_column_names() == ["col3", "col4"]
 
 
-def test_drop_columns_with_missing_values_empty() -> None:
+def test_remove_columns_with_missing_values_empty() -> None:
     table = Table(
         [], TableSchema({"col1": ColumnType.from_numpy_dtype(np.dtype(float))})
     )
-    updated_table = table.drop_columns_with_missing_values()
+    updated_table = table.remove_columns_with_missing_values()
     assert updated_table.get_column_names() == ["col1"]

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_non_numerical_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_non_numerical_values.py
@@ -4,7 +4,7 @@ from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import ColumnType, TableSchema
 
 
-def test_drop_columns_with_non_numerical_values_valid() -> None:
+def test_remove_columns_with_non_numerical_values_valid() -> None:
     table = Table(
         pd.DataFrame(
             data={
@@ -15,13 +15,13 @@ def test_drop_columns_with_non_numerical_values_valid() -> None:
             }
         )
     )
-    updated_table = table.drop_columns_with_non_numerical_values()
+    updated_table = table.remove_columns_with_non_numerical_values()
     assert updated_table.get_column_names() == ["col3", "col4"]
 
 
-def test_drop_columns_with_non_numerical_values_empty() -> None:
+def test_remove_columns_with_non_numerical_values_empty() -> None:
     table = Table(
         [], TableSchema({"col1": ColumnType.from_numpy_dtype(np.dtype(float))})
     )
-    updated_table = table.drop_columns_with_non_numerical_values()
+    updated_table = table.remove_columns_with_non_numerical_values()
     assert updated_table.get_column_names() == ["col1"]

--- a/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
@@ -11,8 +11,8 @@ from tests.helpers import resolve_resource_path
         "test_table_duplicate_rows_no_duplicates.csv",
     ],
 )
-def test_drop_duplicate_rows(path: str) -> None:
+def test_remove_duplicate_rows(path: str) -> None:
     expected_table = Table(pd.DataFrame(data={"A": [1, 4], "B": [2, 5]}))
     table = Table.from_csv_file(resolve_resource_path(path))
-    result_table = table.drop_duplicate_rows()
+    result_table = table.remove_duplicate_rows()
     assert expected_table == result_table

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
@@ -4,7 +4,7 @@ from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import ColumnType, TableSchema
 
 
-def test_drop_rows_with_missing_values_valid() -> None:
+def test_remove_rows_with_missing_values_valid() -> None:
     table = Table(
         pd.DataFrame(
             data={
@@ -15,13 +15,13 @@ def test_drop_rows_with_missing_values_valid() -> None:
             }
         )
     )
-    updated_table = table.drop_rows_with_missing_values()
+    updated_table = table.remove_rows_with_missing_values()
     assert updated_table.count_rows() == 2
 
 
-def test_drop_rows_with_missing_values_empty() -> None:
+def test_remove_rows_with_missing_values_empty() -> None:
     table = Table(
         [], TableSchema({"col1": ColumnType.from_numpy_dtype(np.dtype(float))})
     )
-    updated_table = table.drop_rows_with_missing_values()
+    updated_table = table.remove_rows_with_missing_values()
     assert updated_table.get_column_names() == ["col1"]

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
@@ -4,7 +4,7 @@ from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import ColumnType, TableSchema
 
 
-def test_drop_rows_with_outliers_no_outliers() -> None:
+def test_remove_rows_with_outliers_no_outliers() -> None:
     table = Table(
         pd.DataFrame(
             data={
@@ -15,13 +15,13 @@ def test_drop_rows_with_outliers_no_outliers() -> None:
         )
     )
     names = table.get_column_names()
-    result = table.drop_rows_with_outliers()
+    result = table.remove_rows_with_outliers()
     assert result.count_rows() == 3
     assert result.count_columns() == 3
     assert names == table.get_column_names()
 
 
-def test_drop_rows_with_outliers_with_outliers() -> None:
+def test_remove_rows_with_outliers_with_outliers() -> None:
     input_ = Table(
         pd.DataFrame(
             data={
@@ -44,7 +44,7 @@ def test_drop_rows_with_outliers_with_outliers() -> None:
             }
         )
     )
-    result = input_.drop_rows_with_outliers()
+    result = input_.remove_rows_with_outliers()
 
     expected = Table(
         pd.DataFrame(
@@ -59,10 +59,10 @@ def test_drop_rows_with_outliers_with_outliers() -> None:
     assert result == expected
 
 
-def test_drop_rows_with_outliers_no_rows() -> None:
+def test_remove_rows_with_outliers_no_rows() -> None:
     table = Table(
         [], TableSchema({"col1": ColumnType.from_numpy_dtype(np.dtype(float))})
     )
-    result = table.drop_rows_with_outliers()
+    result = table.remove_rows_with_outliers()
     assert result.count_rows() == 0
     assert result.count_columns() == 1

--- a/tests/safeds/ml/classification/test_ada_boost.py
+++ b/tests/safeds/ml/classification/test_ada_boost.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_regressor = classifier.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/classification/test_decision_tree.py
+++ b/tests/safeds/ml/classification/test_decision_tree.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_regressor = classifier.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/classification/test_gradient_boosting.py
+++ b/tests/safeds/ml/classification/test_gradient_boosting.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_regressor = classifier.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/classification/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/classification/test_k_nearest_neighbors.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_regressor = classifier.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/classification/test_logistic_regression.py
+++ b/tests/safeds/ml/classification/test_logistic_regression.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_regressor = classifier.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/classification/test_random_forest.py
+++ b/tests/safeds/ml/classification/test_random_forest.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_regressor = classifier.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, classifier: Classifier, valid_data: TaggedTable) -> None:
         fitted_classifier = classifier.fit(valid_data)

--- a/tests/safeds/ml/regression/test_ada_boost.py
+++ b/tests/safeds/ml/regression/test_ada_boost.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_decision_tree.py
+++ b/tests/safeds/ml/regression/test_decision_tree.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_elastic_net.py
+++ b/tests/safeds/ml/regression/test_elastic_net.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_gradient_boosting.py
+++ b/tests/safeds/ml/regression/test_gradient_boosting.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_k_nearest_neighbors.py
+++ b/tests/safeds/ml/regression/test_k_nearest_neighbors.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_lasso_regression.py
+++ b/tests/safeds/ml/regression/test_lasso_regression.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_linear_regression.py
+++ b/tests/safeds/ml/regression/test_linear_regression.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_random_forest.py
+++ b/tests/safeds/ml/regression/test_random_forest.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)

--- a/tests/safeds/ml/regression/test_ridge_regression.py
+++ b/tests/safeds/ml/regression/test_ridge_regression.py
@@ -51,8 +51,8 @@ class TestPredict:
 
     def test_should_include_complete_prediction_input(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)
-        prediction = fitted_regressor.predict(valid_data.drop_columns(["target"]))
-        assert prediction.drop_columns(["target"]) == valid_data.drop_columns(["target"])
+        prediction = fitted_regressor.predict(valid_data.remove_columns(["target"]))
+        assert prediction.remove_columns(["target"]) == valid_data.remove_columns(["target"])
 
     def test_should_set_correct_target_name(self, regressor: Regressor, valid_data: TaggedTable) -> None:
         fitted_regressor = regressor.fit(valid_data)


### PR DESCRIPTION
### Summary of Changes

Rename the `drop_XY` methods of `Table` to `remove_XY`. When users want to get rid of columns, they will probably look for "remove", particularly, since the names of methods to include new columns and rows start with "add".
