### PR TITLE
feat: rename `shuffle` to `shuffle_rows`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -769,7 +769,7 @@ class Table:
         result[new_column.name] = new_column._data
         return Table(result)
 
-    def shuffle(self) -> Table:
+    def shuffle_rows(self) -> Table:
         """
         Shuffle the table randomly.
 

--- a/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
@@ -2,7 +2,7 @@ import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
-def test_shuffle_valid() -> None:
+def test_shuffle_rows_valid() -> None:
     table = Table(pd.DataFrame(data={"col1": [1], "col2": [1]}))
-    result_table = table.shuffle()
+    result_table = table.shuffle_rows()
     assert table == result_table


### PR DESCRIPTION
### Summary of Changes

To be consistent with the other methods of `Table`, I've rename `shuffle` to `shuffle_rows`. This makes it obvious that the columns are not changed.