### PR TITLE
feat: rename `slice` to `slice_rows`

### DIFF
--- a/docs/tutorials/data_processing.ipynb
+++ b/docs/tutorials/data_processing.ipynb
@@ -49,7 +49,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "titanic_slice = titanic.slice(end=10)\n",
+    "titanic_slice = titanic.slice_rows(end=10)\n",
     "\n",
     "titanic_slice # just to show the output"
    ],

--- a/docs/tutorials/data_visualization.ipynb
+++ b/docs/tutorials/data_visualization.ipynb
@@ -46,7 +46,7 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "titanic.slice(end=10)"
+    "titanic.slice_rows(end=10)"
    ],
    "metadata": {
     "collapsed": false,

--- a/docs/tutorials/machine_learning.ipynb
+++ b/docs/tutorials/machine_learning.ipynb
@@ -21,7 +21,6 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "from safeds.data.tabular.containers import TaggedTable\n",
     "from safeds.data.tabular.containers import Table\n",
     "\n",
     "training_set = Table({\n",

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -783,7 +783,7 @@ class Table:
         new_df.columns = self._schema.get_column_names()
         return Table(new_df)
 
-    def slice(
+    def slice_rows(
         self,
         start: Optional[int] = None,
         end: Optional[int] = None,
@@ -901,8 +901,8 @@ class Table:
         if percentage_in_first <= 0 or percentage_in_first >= 1:
             raise ValueError("the given percentage is not in range")
         return (
-            self.slice(0, round(percentage_in_first * self.count_rows())),
-            self.slice(round(percentage_in_first * self.count_rows())),
+            self.slice_rows(0, round(percentage_in_first * self.count_rows())),
+            self.slice_rows(round(percentage_in_first * self.count_rows())),
         )
 
     def tag_columns(self, target_name: str, feature_names: Optional[list[str]] = None) -> TaggedTable:

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -3,31 +3,31 @@ import pytest
 from safeds.data.tabular.containers import Table
 
 
-def test_slice_valid() -> None:
+def test_slice_rows_valid() -> None:
     table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
     test_table = Table(pd.DataFrame(data={"col1": [1, 2], "col2": [1, 2]}))
     second_test_table = Table(pd.DataFrame(data={"col1": [1, 1], "col2": [1, 4]}))
-    new_table = table.slice(0, 2, 1)
-    second_new_table = table.slice(0, 3, 2)
-    third_new_table = table.slice()
+    new_table = table.slice_rows(0, 2, 1)
+    second_new_table = table.slice_rows(0, 3, 2)
+    third_new_table = table.slice_rows()
     assert new_table == test_table
     assert second_new_table == second_test_table
     assert third_new_table == table
 
 
-def test_slice_invalid() -> None:
+def test_slice_rows_invalid() -> None:
     table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
 
     with pytest.raises(ValueError):
-        table.slice(3, 2, 1)
+        table.slice_rows(3, 2, 1)
     with pytest.raises(ValueError):
-        table.slice(4, 0, 1)
+        table.slice_rows(4, 0, 1)
 
     with pytest.raises(ValueError):
-        table.slice(0, 4, 1)
+        table.slice_rows(0, 4, 1)
 
     with pytest.raises(ValueError):
-        table.slice(-4, 0, 1)
+        table.slice_rows(-4, 0, 1)
 
     with pytest.raises(ValueError):
-        table.slice(0, -4, 1)
+        table.slice_rows(0, -4, 1)


### PR DESCRIPTION
### Summary of Changes

To be consistent with the other methods of `Table`, I've rename `slice` to `slice_rows`. This makes it obvious that the columns are not changed.
