### PR TITLE
feat: create empty `Table` without schema

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -194,11 +194,9 @@ class Table:
     def __init__(self, data: Iterable, schema: Optional[TableSchema] = None):
         self._data: pd.Dataframe = data if isinstance(data, pd.DataFrame) else pd.DataFrame(data)
         if schema is None:
-            if self.count_columns() == 0:
-                raise MissingSchemaError()
             self._schema: TableSchema = TableSchema._from_dataframe(self._data)
         else:
-            self._schema = schema
+            self._schema: TableSchema = schema
             if self._data.empty:
                 self._data = pd.DataFrame(columns=self._schema.get_column_names())
 

--- a/tests/safeds/data/tabular/containers/_table/test_table.py
+++ b/tests/safeds/data/tabular/containers/_table/test_table.py
@@ -11,3 +11,8 @@ def test_create_empty_table() -> None:
     assert col.count() == 0
     assert isinstance(col.type, type(ColumnType.from_numpy_dtype(np.dtype(float))))
     assert col.name == "col1"
+
+
+def test_create_empty_table_without_schema() -> None:
+    table = Table([])
+    assert table.schema == TableSchema({})


### PR DESCRIPTION
### Summary of Changes

We no longer raise an exception when a user creates an empty `Table` without specifying a schema. `Table([])` is now allows.

`add_row` and `add_rows` must still be adjusted (#127) to allow adding rows to such an empty `Table`.
