### PR TITLE
fix: export `TableTransformer` and `InvertibleTableTransformer`

### DIFF
--- a/src/safeds/data/tabular/transformation/__init__.py
+++ b/src/safeds/data/tabular/transformation/__init__.py
@@ -1,3 +1,4 @@
 from ._imputer import Imputer, ImputerStrategy
 from ._label_encoder import LabelEncoder
 from ._one_hot_encoder import OneHotEncoder
+from ._table_transformer import TableTransformer, InvertibleTableTransformer

--- a/src/safeds/data/tabular/transformation/__init__.py
+++ b/src/safeds/data/tabular/transformation/__init__.py
@@ -1,4 +1,4 @@
 from ._imputer import Imputer, ImputerStrategy
 from ._label_encoder import LabelEncoder
 from ._one_hot_encoder import OneHotEncoder
-from ._table_transformer import TableTransformer, InvertibleTableTransformer
+from ._table_transformer import InvertibleTableTransformer, TableTransformer


### PR DESCRIPTION
### Summary of Changes

`TableTransformer` and `InvertibleTableTransformer` are now included in the correct `__init__` file, so they show up in the documentation.