### PR TITLE
fix: `table.keep_only_columns` now maps column names to correct data

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -578,7 +578,7 @@ class Table:
         if len(invalid_columns) != 0:
             raise UnknownColumnNameError(invalid_columns)
         transformed_data = self._data[column_indices]
-        transformed_data.columns = [self._schema.get_column_names()[i] for i in column_indices]
+        transformed_data.columns = column_names
         return Table(transformed_data)
 
     def remove_columns(self, column_names: list[str]) -> Table:

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -566,7 +566,7 @@ class Table:
         Raises
         ------
         ColumnNameError
-            If any of the given columns do not exist.
+            If any of the given columns does not exist.
         """
         invalid_columns = []
         column_indices = []
@@ -578,7 +578,7 @@ class Table:
         if len(invalid_columns) != 0:
             raise UnknownColumnNameError(invalid_columns)
         transformed_data = self._data[column_indices]
-        transformed_data.columns = [name for name in self._schema.get_column_names() if name in column_names]
+        transformed_data.columns = [self._schema.get_column_names()[i] for i in column_indices]
         return Table(transformed_data)
 
     def remove_columns(self, column_names: list[str]) -> Table:
@@ -598,7 +598,7 @@ class Table:
         Raises
         ------
         ColumnNameError
-            If any of the given columns do not exist.
+            If any of the given columns does not exist.
         """
         invalid_columns = []
         column_indices = []

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -129,14 +129,9 @@ class Table:
 
         Raises
         ------
-        MissingDataError
-            If an empty list is given.
         ColumnLengthMismatchError
             If any of the column sizes does not match with the others.
         """
-        if len(columns) == 0:
-            raise MissingDataError("This function requires at least one column.")
-
         dataframe: DataFrame = pd.DataFrame()
 
         for column in columns:

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,6 +1,6 @@
 import pandas as pd
-
 from safeds.data.tabular.containers import Column, Table
+
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,8 +1,6 @@
 import pandas as pd
-import pytest
-from safeds.data.tabular.containers import Column, Table
-from safeds.data.tabular.exceptions import MissingDataError
 
+from safeds.data.tabular.containers import Column, Table
 from tests.helpers import resolve_resource_path
 
 
@@ -15,8 +13,3 @@ def test_from_columns() -> None:
     table_restored: Table = Table.from_columns(columns_table)
 
     assert table_restored == table_expected
-
-
-def test_from_columns_invalid() -> None:
-    with pytest.raises(MissingDataError):
-        Table.from_columns([])

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -12,6 +12,15 @@ def test_keep_columns() -> None:
     assert not transformed_table.schema.has_column("B")
 
 
+def test_keep_columns_order() -> None:
+    table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
+    transformed_table = table.keep_only_columns(["B", "A"])
+    assert table.to_columns()[0] == transformed_table.to_columns()[1]
+    assert table.to_columns()[1] == transformed_table.to_columns()[0]
+    assert table.get_column("A") == transformed_table.get_column("A")
+    assert table.get_column("B") == transformed_table.get_column("B")
+
+
 def test_keep_columns_warning() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
     with pytest.raises(UnknownColumnNameError):

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Table
+from safeds.data.tabular.containers import Table, Column
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 from tests.helpers import resolve_resource_path
@@ -15,10 +15,12 @@ def test_keep_only_columns() -> None:
 def test_keep_only_columns_order() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
     transformed_table = table.keep_only_columns(["B", "A"])
-    assert table.to_columns()[0] == transformed_table.to_columns()[1]
-    assert table.to_columns()[1] == transformed_table.to_columns()[0]
-    assert table.get_column("A") == transformed_table.get_column("A")
-    assert table.get_column("B") == transformed_table.get_column("B")
+    assert transformed_table == Table.from_columns(
+        [
+            Column("B", [2]),
+            Column("A", [1])
+        ]
+    )
 
 
 def test_keep_only_columns_warning() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -1,29 +1,46 @@
 import pytest
+
 from safeds.data.tabular.containers import Table, Column
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 
-from tests.helpers import resolve_resource_path
 
-
-def test_keep_only_columns() -> None:
-    table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
-    transformed_table = table.keep_only_columns(["A"])
-    assert transformed_table.schema.has_column("A")
-    assert not transformed_table.schema.has_column("B")
-
-
-def test_keep_only_columns_order() -> None:
-    table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
-    transformed_table = table.keep_only_columns(["B", "A"])
-    assert transformed_table == Table.from_columns(
+class TestKeepOnlyColumns:
+    @pytest.mark.parametrize(
+        ("table", "column_names", "expected"),
         [
-            Column("B", [2]),
-            Column("A", [1])
+            (
+                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                [],
+                Table.from_columns([]),
+            ),
+            (
+                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                ["A"],
+                Table.from_columns([Column("A", [1])]),
+            ),
+            (
+                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                ["B"],
+                Table.from_columns([Column("B", [2])]),
+            ),
+            (
+                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                ["A", "B"],
+                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+            ),
+            # Related to https://github.com/Safe-DS/Stdlib/issues/115
+            (
+                Table.from_columns([Column("A", [1]), Column("B", [2]), Column("C", [3])]),
+                ["C", "A"],
+                Table.from_columns([Column("C", [3]), Column("A", [1])]),
+            ),
         ]
     )
+    def test_should_keep_only_listed_columns(self, table: Table, column_names: list[str], expected: Table):
+        transformed_table = table.keep_only_columns(column_names)
+        assert transformed_table == expected
 
-
-def test_keep_only_columns_warning() -> None:
-    table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
-    with pytest.raises(UnknownColumnNameError):
-        table.keep_only_columns(["C"])
+    def test_raise_if_column_does_no_exist(self):
+        table = Table.from_columns([Column("A", [1]), Column("B", [2])])
+        with pytest.raises(UnknownColumnNameError):
+            table.keep_only_columns(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -12,7 +12,7 @@ def test_keep_columns() -> None:
     assert not transformed_table.schema.has_column("B")
 
 
-def test_keep_columns_order() -> None:
+def test_keep_only_columns_order() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
     transformed_table = table.keep_only_columns(["B", "A"])
     assert table.to_columns()[0] == transformed_table.to_columns()[1]
@@ -21,7 +21,7 @@ def test_keep_columns_order() -> None:
     assert table.get_column("B") == transformed_table.get_column("B")
 
 
-def test_keep_columns_warning() -> None:
+def test_keep_only_columns_warning() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
     with pytest.raises(UnknownColumnNameError):
         table.keep_only_columns(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.exceptions import UnknownColumnNameError
 from tests.helpers import resolve_resource_path
 
 
-def test_keep_columns() -> None:
+def test_keep_only_columns() -> None:
     table = Table.from_csv_file(resolve_resource_path("test_table_from_csv_file.csv"))
     transformed_table = table.keep_only_columns(["A"])
     assert transformed_table.schema.has_column("A")

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -1,6 +1,5 @@
 import pytest
-
-from safeds.data.tabular.containers import Table, Column
+from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 
@@ -34,7 +33,7 @@ class TestKeepOnlyColumns:
                 ["C", "A"],
                 Table.from_columns([Column("C", [3]), Column("A", [1])]),
             ),
-        ]
+        ],
     )
     def test_should_keep_only_listed_columns(self, table: Table, column_names: list[str], expected: Table) -> None:
         transformed_table = table.keep_only_columns(column_names)

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -36,11 +36,11 @@ class TestKeepOnlyColumns:
             ),
         ]
     )
-    def test_should_keep_only_listed_columns(self, table: Table, column_names: list[str], expected: Table):
+    def test_should_keep_only_listed_columns(self, table: Table, column_names: list[str], expected: Table) -> None:
         transformed_table = table.keep_only_columns(column_names)
         assert transformed_table == expected
 
-    def test_raise_if_column_does_no_exist(self):
+    def test_should_raise_if_column_does_no_exist(self) -> None:
         table = Table.from_columns([Column("A", [1]), Column("B", [2])])
         with pytest.raises(UnknownColumnNameError):
             table.keep_only_columns(["C"])


### PR DESCRIPTION
Closes #115 .

### Summary of Changes

Fixed `table.keep_only_columns` to rearrange the column names correctly
Fixed grammar in two docs