### PR TITLE
feat: `OneHotEncoder.inverse_transform` now maintains the column order from the original table

### DIFF
--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pandas as pd
 from sklearn.preprocessing import OneHotEncoder as sk_OneHotEncoder
 
@@ -9,7 +11,9 @@ from safeds.data.tabular.exceptions import TransformerNotFittedError, \
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
-from safeds.data.tabular.typing import Schema
+
+if TYPE_CHECKING:
+    from safeds.data.tabular.typing import Schema
 
 
 class OneHotEncoder(InvertibleTableTransformer):

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -51,7 +51,6 @@ class OneHotEncoder(InvertibleTableTransformer):
         result = OneHotEncoder()
         result._wrapped_transformer = wrapped_transformer
         result._column_names = column_names
-        result._original_schema = table.schema
 
         return result
 

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -50,7 +50,8 @@ class OneHotEncoder(InvertibleTableTransformer):
         result = OneHotEncoder()
         result._wrapped_transformer = wrapped_transformer
         result._column_names = {
-            column: [f"{column}_{element}" for element in table.get_column(column)] for column in column_names
+            column: [f"{column}_{element}" for element in table.get_column(column).get_unique_values()]
+            for column in column_names
         }
 
         return result

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from typing import Callable
+
 import pandas as pd
 from sklearn.preprocessing import OneHotEncoder as sk_OneHotEncoder
 
-from safeds.data.tabular.containers import Table
-from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
+from safeds.data.tabular.containers import Table, Column
+from safeds.data.tabular.exceptions import TransformerNotFittedError, \
+    UnknownColumnNameError
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
@@ -130,7 +133,8 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         res = Table(pd.concat([unchanged, decoded], axis=1))
         column_names = self._original_schema.get_column_names()
-        res = res.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
+        sort_func: Callable[[Column, Column], int] = lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name)
+        res = res.sort_columns(sort_func)
 
         return res
 

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -6,8 +6,7 @@ import pandas as pd
 from sklearn.preprocessing import OneHotEncoder as sk_OneHotEncoder
 
 from safeds.data.tabular.containers import Table
-from safeds.data.tabular.exceptions import TransformerNotFittedError, \
-    UnknownColumnNameError
+from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
@@ -128,7 +127,9 @@ class OneHotEncoder(InvertibleTableTransformer):
         data.columns = transformed_table.get_column_names()
 
         decoded = pd.DataFrame(
-            self._wrapped_transformer.inverse_transform(transformed_table.keep_only_columns(self._wrapped_transformer.get_feature_names_out())._data),
+            self._wrapped_transformer.inverse_transform(
+                transformed_table.keep_only_columns(self._wrapped_transformer.get_feature_names_out())._data,
+            ),
             columns=self._column_names,
         )
         unchanged = data.drop(self._wrapped_transformer.get_feature_names_out(), axis=1)

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -49,7 +49,9 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         result = OneHotEncoder()
         result._wrapped_transformer = wrapped_transformer
-        result._column_names = {column:[column + "_" + element for element in table.get_column(column)] for column in column_names}
+        result._column_names = {
+            column: [column + "_" + element for element in table.get_column(column)] for column in column_names
+        }
 
         return result
 
@@ -85,7 +87,9 @@ class OneHotEncoder(InvertibleTableTransformer):
         original = table._data.copy()
         original.columns = table.schema.get_column_names()
 
-        one_hot_encoded = pd.DataFrame(self._wrapped_transformer.transform(original[self._column_names.keys()]).toarray())
+        one_hot_encoded = pd.DataFrame(
+            self._wrapped_transformer.transform(original[self._column_names.keys()]).toarray(),
+        )
         one_hot_encoded.columns = self._wrapped_transformer.get_feature_names_out()
 
         unchanged = original.drop(self._column_names.keys(), axis=1)
@@ -140,7 +144,18 @@ class OneHotEncoder(InvertibleTableTransformer):
         unchanged = data.drop(self._wrapped_transformer.get_feature_names_out(), axis=1)
 
         res = Table(pd.concat([unchanged, decoded], axis=1))
-        column_names = [name if name not in [value for value_list in list(self._column_names.values()) for value in value_list] else list(self._column_names.keys())[[list(self._column_names.values()).index(value) for value in list(self._column_names.values()) if name in value][0]] for name in transformed_table.get_column_names()]
+        column_names = [
+            name
+            if name not in [value for value_list in list(self._column_names.values()) for value in value_list]
+            else list(self._column_names.keys())[
+                [
+                    list(self._column_names.values()).index(value)
+                    for value in list(self._column_names.values())
+                    if name in value
+                ][0]
+            ]
+            for name in transformed_table.get_column_names()
+        ]
         res = res.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
 
         return res

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -15,7 +15,7 @@ class OneHotEncoder(InvertibleTableTransformer):
 
     def __init__(self) -> None:
         self._wrapped_transformer: sk_OneHotEncoder | None = None
-        self._column_names: list[str] | None = None
+        self._column_names: dict[str, list[str]] | None = None
 
     # noinspection PyProtectedMember
     def fit(self, table: Table, column_names: list[str] | None = None) -> OneHotEncoder:
@@ -49,7 +49,7 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         result = OneHotEncoder()
         result._wrapped_transformer = wrapped_transformer
-        result._column_names = column_names
+        result._column_names = {column:[column + "_" + element for element in table.get_column(column)] for column in column_names}
 
         return result
 
@@ -78,23 +78,23 @@ class OneHotEncoder(InvertibleTableTransformer):
             raise TransformerNotFittedError
 
         # Input table does not contain all columns used to fit the transformer
-        missing_columns = set(self._column_names) - set(table.get_column_names())
+        missing_columns = set(self._column_names.keys()) - set(table.get_column_names())
         if len(missing_columns) > 0:
             raise UnknownColumnNameError(list(missing_columns))
 
         original = table._data.copy()
         original.columns = table.schema.get_column_names()
 
-        one_hot_encoded = pd.DataFrame(self._wrapped_transformer.transform(original[self._column_names]).toarray())
+        one_hot_encoded = pd.DataFrame(self._wrapped_transformer.transform(original[self._column_names.keys()]).toarray())
         one_hot_encoded.columns = self._wrapped_transformer.get_feature_names_out()
 
-        unchanged = original.drop(self._column_names, axis=1)
+        unchanged = original.drop(self._column_names.keys(), axis=1)
 
         res = Table(pd.concat([unchanged, one_hot_encoded], axis=1))
         column_names = []
 
         for name in table.get_column_names():
-            if name not in self._column_names:
+            if name not in self._column_names.keys():
                 column_names.append(name)
             else:
                 column_names.extend(
@@ -135,17 +135,12 @@ class OneHotEncoder(InvertibleTableTransformer):
             self._wrapped_transformer.inverse_transform(
                 transformed_table.keep_only_columns(self._wrapped_transformer.get_feature_names_out())._data,
             ),
-            columns=self._column_names,
+            columns=list(self._column_names.keys()),
         )
         unchanged = data.drop(self._wrapped_transformer.get_feature_names_out(), axis=1)
 
         res = Table(pd.concat([unchanged, decoded], axis=1))
-        column_names = [
-            name
-            if name not in self._wrapped_transformer.get_feature_names_out()
-            else [col for col in self._column_names if name.startswith(col)][0]
-            for name in transformed_table.get_column_names()
-        ]
+        column_names = [name if name not in [value for value_list in list(self._column_names.values()) for value in value_list] else list(self._column_names.keys())[[list(self._column_names.values()).index(value) for value in list(self._column_names.values()) if name in value][0]] for name in transformed_table.get_column_names()]
         res = res.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
 
         return res

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -4,8 +4,7 @@ import pandas as pd
 from sklearn.preprocessing import OneHotEncoder as sk_OneHotEncoder
 
 from safeds.data.tabular.containers import Table
-from safeds.data.tabular.exceptions import TransformerNotFittedError, \
-    UnknownColumnNameError
+from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
@@ -92,13 +91,15 @@ class OneHotEncoder(InvertibleTableTransformer):
         unchanged = original.drop(self._column_names, axis=1)
 
         res = Table(pd.concat([unchanged, one_hot_encoded], axis=1))
-        column_names = list()
+        column_names = []
 
         for name in table.get_column_names():
             if name not in self._column_names:
                 column_names.append(name)
             else:
-                column_names.extend([f_name for f_name in self._wrapped_transformer.get_feature_names_out() if f_name.startswith(name)])
+                column_names.extend(
+                    [f_name for f_name in self._wrapped_transformer.get_feature_names_out() if f_name.startswith(name)],
+                )
         res = res.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
 
         return res
@@ -139,7 +140,12 @@ class OneHotEncoder(InvertibleTableTransformer):
         unchanged = data.drop(self._wrapped_transformer.get_feature_names_out(), axis=1)
 
         res = Table(pd.concat([unchanged, decoded], axis=1))
-        column_names = [name if name not in self._wrapped_transformer.get_feature_names_out() else [col for col in self._column_names if name.startswith(col)][0] for name in transformed_table.get_column_names()]
+        column_names = [
+            name
+            if name not in self._wrapped_transformer.get_feature_names_out()
+            else [col for col in self._column_names if name.startswith(col)][0]
+            for name in transformed_table.get_column_names()
+        ]
         res = res.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
 
         return res

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -9,16 +9,16 @@ from safeds.data.tabular.exceptions import TransformerNotFittedError, \
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
+from safeds.data.tabular.typing import Schema
 
 
 class OneHotEncoder(InvertibleTableTransformer):
     """Encodes categorical columns to numerical features [0,1] that represent the existence for each value."""
 
-    _original_schema = None
-
     def __init__(self) -> None:
         self._wrapped_transformer: sk_OneHotEncoder | None = None
         self._column_names: list[str] | None = None
+        self._original_schema: Schema | None = None
 
     # noinspection PyProtectedMember
     def fit(self, table: Table, column_names: list[str] | None = None) -> OneHotEncoder:
@@ -117,7 +117,7 @@ class OneHotEncoder(InvertibleTableTransformer):
             If the transformer has not been fitted yet.
         """
         # Transformer has not been fitted yet
-        if self._wrapped_transformer is None or self._column_names is None:
+        if self._wrapped_transformer is None or self._column_names is None or self._original_schema is None:
             raise TransformerNotFittedError
 
         data = transformed_table._data.copy()

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -50,7 +50,7 @@ class OneHotEncoder(InvertibleTableTransformer):
         result = OneHotEncoder()
         result._wrapped_transformer = wrapped_transformer
         result._column_names = {
-            column: [column + "_" + element for element in table.get_column(column)] for column in column_names
+            column: [f"{column}_{element}" for element in table.get_column(column)] for column in column_names
         }
 
         return result

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -1,26 +1,24 @@
 from __future__ import annotations
 
-from typing import Callable
-
 import pandas as pd
 from sklearn.preprocessing import OneHotEncoder as sk_OneHotEncoder
 
-from safeds.data.tabular.containers import Table, Column
+from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import TransformerNotFittedError, \
     UnknownColumnNameError
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
-from safeds.data.tabular.typing import Schema
 
 
 class OneHotEncoder(InvertibleTableTransformer):
     """Encodes categorical columns to numerical features [0,1] that represent the existence for each value."""
 
+    _original_schema = None
+
     def __init__(self) -> None:
         self._wrapped_transformer: sk_OneHotEncoder | None = None
         self._column_names: list[str] | None = None
-        self._original_schema: Schema | None = None
 
     # noinspection PyProtectedMember
     def fit(self, table: Table, column_names: list[str] | None = None) -> OneHotEncoder:
@@ -133,8 +131,7 @@ class OneHotEncoder(InvertibleTableTransformer):
 
         res = Table(pd.concat([unchanged, decoded], axis=1))
         column_names = self._original_schema.get_column_names()
-        sort_func: Callable[[Column, Column], int] = lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name)
-        res = res.sort_columns(sort_func)
+        res = res.sort_columns(lambda col1, col2: column_names.index(col1.name) - column_names.index(col2.name))
 
         return res
 

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -234,10 +234,11 @@ class TestInverseTransform:
 
         result = transformer.inverse_transform(transformer.transform(table_to_transform))
 
+        # This checks whether the columns are in the same order
+        assert result.get_column_names() == table_to_transform.get_column_names()
         # This is subsumed by the next assertion, but we get a better error message
         assert result.schema == table_to_transform.schema
         assert result == table_to_transform
-        assert result.get_column_names() == table_to_transform.get_column_names()
 
     def test_should_not_change_transformed_table(self) -> None:
         table = Table.from_dict(

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -134,11 +134,7 @@ class TestFitAndTransform:
                 ),
             ),
         ],
-        ids=[
-            "all columns",
-            "one column",
-            "multiple columns"
-        ]
+        ids=["all columns", "one column", "multiple columns"],
     )
     def test_should_return_transformed_table(
         self,
@@ -185,7 +181,7 @@ class TestInverseTransform:
                         "b": ["a", "b", "b", "c"],
                         "c": [0.0, 0.0, 0.0, 1.0],
                     },
-                )
+                ),
             ),
             (
                 Table.from_dict(
@@ -202,7 +198,7 @@ class TestInverseTransform:
                         "b": ["a", "b", "b", "c"],
                         "a": [1.0, 0.0, 0.0, 0.0],
                     },
-                )
+                ),
             ),
             (
                 Table.from_dict(
@@ -219,7 +215,7 @@ class TestInverseTransform:
                         "b": ["a", "b", "b", "c"],
                         "bb": ["a", "b", "b", "c"],
                     },
-                )
+                ),
             ),
         ],
         ids=[

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -217,10 +217,10 @@ class TestInverseTransform:
         table_different_order = table.sort_columns()
         transformer = OneHotEncoder().fit(table, ["b"])
 
-        inverse_transformed_table = transformer.inverse_transform(
-            transformer.transform(table))
+        inverse_transformed_table = transformer.inverse_transform(transformer.transform(table))
         inverse_transformed_table_different_order = transformer.inverse_transform(
-            transformer.transform(table_different_order))
+            transformer.transform(table_different_order),
+        )
         assert inverse_transformed_table == inverse_transformed_table_different_order
         assert inverse_transformed_table.get_column_names() == ["c", "b", "a"]
         assert inverse_transformed_table_different_order.get_column_names() == ["a", "b", "c"]

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -205,4 +205,3 @@ class TestInverseTransform:
         inverse_transformed_table = transformer.inverse_transform(transformer.transform(table))
         assert table.get_column_names() == inverse_transformed_table.get_column_names()
         assert table == inverse_transformed_table
-

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -157,7 +157,7 @@ class TestInverseTransform:
                         "col1": ["a", "b", "b", "c"],
                     },
                 ),
-                None
+                None,
             ),
             (
                 Table.from_dict(
@@ -197,14 +197,11 @@ class TestInverseTransform:
         ids=[
             "one column",
             "same table to fit and transform (issue #109)",
-            "different tables to fit and transform (issue #109)"
-        ]
+            "different tables to fit and transform (issue #109)",
+        ],
     )
     def test_should_return_original_table(
-        self,
-        table_to_fit: Table,
-        table_to_transform: Table,
-        column_names: list[str]
+        self, table_to_fit: Table, table_to_transform: Table, column_names: list[str],
     ) -> None:
         transformer = OneHotEncoder().fit(table_to_fit, column_names)
 

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -237,6 +237,7 @@ class TestInverseTransform:
         # This is subsumed by the next assertion, but we get a better error message
         assert result.schema == table_to_transform.schema
         assert result == table_to_transform
+        assert result.get_column_names() == table_to_transform.get_column_names()
 
     def test_should_not_change_transformed_table(self) -> None:
         table = Table.from_dict(

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -107,10 +107,10 @@ class TestFitAndTransform:
                 ["col1"],
                 Table.from_columns(
                     [
-                        Column("col2", ["a", "b", "b", "c"]),
                         Column("col1_a", [1.0, 0.0, 0.0, 0.0]),
                         Column("col1_b", [0.0, 1.0, 1.0, 0.0]),
                         Column("col1_c", [0.0, 0.0, 0.0, 1.0]),
+                        Column("col2", ["a", "b", "b", "c"]),
                     ],
                 ),
             ),
@@ -205,3 +205,22 @@ class TestInverseTransform:
         inverse_transformed_table = transformer.inverse_transform(transformer.transform(table))
         assert table.get_column_names() == inverse_transformed_table.get_column_names()
         assert table == inverse_transformed_table
+
+    def test_inverse_transform_different_order(self) -> None:
+        table = Table.from_columns(
+            [
+                Column("c", [0.0, 0.0, 0.0, 1.0]),
+                Column("b", [0.0, 1.0, 1.0, 0.0]),
+                Column("a", [1.0, 0.0, 0.0, 0.0]),
+            ],
+        )
+        table_different_order = table.sort_columns()
+        transformer = OneHotEncoder().fit(table, ["b"])
+
+        inverse_transformed_table = transformer.inverse_transform(
+            transformer.transform(table))
+        inverse_transformed_table_different_order = transformer.inverse_transform(
+            transformer.transform(table_different_order))
+        assert inverse_transformed_table == inverse_transformed_table_different_order
+        assert inverse_transformed_table.get_column_names() == ["c", "b", "a"]
+        assert inverse_transformed_table_different_order.get_column_names() == ["a", "b", "c"]

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -192,3 +192,17 @@ class TestInverseTransform:
 
         with pytest.raises(TransformerNotFittedError):
             transformer.inverse_transform(table)
+
+    def test_inverse_transform_not_complete_table(self) -> None:
+        table = Table.from_columns(
+            [
+                Column("a", [1.0, 0.0, 0.0, 0.0]),
+                Column("b", [0.0, 1.0, 1.0, 0.0]),
+                Column("c", [0.0, 0.0, 0.0, 1.0]),
+            ],
+        )
+        transformer = OneHotEncoder().fit(table, ["b"])
+        inverse_transformed_table = transformer.inverse_transform(transformer.transform(table))
+        assert table.get_column_names() == inverse_transformed_table.get_column_names()
+        assert table == inverse_transformed_table
+

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -105,13 +105,13 @@ class TestFitAndTransform:
                     },
                 ),
                 ["col1"],
-                Table.from_columns(
-                    [
-                        Column("col1_a", [1.0, 0.0, 0.0, 0.0]),
-                        Column("col1_b", [0.0, 1.0, 1.0, 0.0]),
-                        Column("col1_c", [0.0, 0.0, 0.0, 1.0]),
-                        Column("col2", ["a", "b", "b", "c"]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1_a": [1.0, 0.0, 0.0, 0.0],
+                        "col1_b": [0.0, 1.0, 1.0, 0.0],
+                        "col1_c": [0.0, 0.0, 0.0, 1.0],
+                        "col2": ["a", "b", "b", "c"],
+                    },
                 ),
             ),
         ],
@@ -194,12 +194,12 @@ class TestInverseTransform:
             transformer.inverse_transform(table)
 
     def test_inverse_transform_not_complete_table(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1.0, 0.0, 0.0, 0.0]),
-                Column("b", [0.0, 1.0, 1.0, 0.0]),
-                Column("c", [0.0, 0.0, 0.0, 1.0]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1.0, 0.0, 0.0, 0.0],
+                "b": [0.0, 1.0, 1.0, 0.0],
+                "c": [0.0, 0.0, 0.0, 1.0],
+            },
         )
         transformer = OneHotEncoder().fit(table, ["b"])
         inverse_transformed_table = transformer.inverse_transform(transformer.transform(table))
@@ -207,12 +207,12 @@ class TestInverseTransform:
         assert table == inverse_transformed_table
 
     def test_inverse_transform_different_order(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("c", [0.0, 0.0, 0.0, 1.0]),
-                Column("b", [0.0, 1.0, 1.0, 0.0]),
-                Column("a", [1.0, 0.0, 0.0, 0.0]),
-            ],
+        table = Table.from_dict(
+            {
+                "c": [0.0, 0.0, 0.0, 1.0],
+                "b": [0.0, 1.0, 1.0, 0.0],
+                "a": [1.0, 0.0, 0.0, 0.0],
+            },
         )
         table_different_order = table.sort_columns()
         transformer = OneHotEncoder().fit(table, ["b"])

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -201,7 +201,10 @@ class TestInverseTransform:
         ],
     )
     def test_should_return_original_table(
-        self, table_to_fit: Table, table_to_transform: Table, column_names: list[str],
+        self,
+        table_to_fit: Table,
+        table_to_transform: Table,
+        column_names: list[str],
     ) -> None:
         transformer = OneHotEncoder().fit(table_to_fit, column_names)
 


### PR DESCRIPTION
Closes #109.

### Summary of Changes

`OneHotEncoder.inverse_transform` now maintains the column order from the original table (#109)
Fixed bug with `OneHotEncoder.inverse_transform` to not work if not all columns were fitted
New feature columns in `OneHotEncoder` will now be inserted where the combined columns were in the original table