### PR TITLE
feat: convert between a `dict` and a `Table`

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -132,7 +132,6 @@ class Table:
         ColumnLengthMismatchError
             If columns have different lengths.
         """
-
         # Validation
         expected_length: int | None = None
         for column_values in data.values():
@@ -855,7 +854,7 @@ class Table:
     def sort_columns(
         self,
         comparator: Callable[[Column, Column], int] = lambda col1, col2: (col1.name > col2.name)
-                                                                         - (col1.name < col2.name),
+        - (col1.name < col2.name),
     ) -> Table:
         """
         Sort the columns of a `Table` with the given comparator and return a new `Table`.
@@ -1149,10 +1148,7 @@ class Table:
         data : dict[str, list[Any]]
             Dictionary representation of the table.
         """
-        return {
-            column_name: list(self.get_column(column_name))
-            for column_name in self.get_column_names()
-        }
+        return {column_name: list(self.get_column(column_name)) for column_name in self.get_column_names()}
 
     def to_columns(self) -> list[Column]:
         """

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -113,6 +113,43 @@ class Table:
             raise FileNotFoundError(f'File "{path}" does not exist') from exception
 
     @staticmethod
+    def from_dict(data: dict[str, list[Any]]) -> Table:
+        """
+        Create a table from a dictionary that maps column names to column values.
+
+        Parameters
+        ----------
+        data : dict[str, list[Any]]
+            The data.
+
+        Returns
+        -------
+        table : Table
+            The generated table.
+
+        Raises
+        ------
+        ColumnLengthMismatchError
+            If columns have different lengths.
+        """
+
+        # Validation
+        expected_length: int | None = None
+        for column_values in data.values():
+            if expected_length is None:
+                expected_length = len(column_values)
+            elif len(column_values) != expected_length:
+                raise ColumnLengthMismatchError(
+                    "\n".join(f"{column_name}: {len(column_values)}" for column_name, column_values in data.items()),
+                )
+
+        # Implementation
+        dataframe: DataFrame = pd.DataFrame()
+        for column_name, column_values in data.items():
+            dataframe[column_name] = column_values
+        return Table(dataframe)
+
+    @staticmethod
     def from_columns(columns: list[Column]) -> Table:
         """
         Return a table created from a list of columns.
@@ -137,7 +174,7 @@ class Table:
         for column in columns:
             if column._data.size != columns[0]._data.size:
                 raise ColumnLengthMismatchError(
-                    "\n".join([f"{column.name}: {column._data.size}" for column in columns]),
+                    "\n".join(f"{column.name}: {column._data.size}" for column in columns),
                 )
             dataframe[column.name] = column._data
 
@@ -818,7 +855,7 @@ class Table:
     def sort_columns(
         self,
         comparator: Callable[[Column, Column], int] = lambda col1, col2: (col1.name > col2.name)
-        - (col1.name < col2.name),
+                                                                         - (col1.name < col2.name),
     ) -> Table:
         """
         Sort the columns of a `Table` with the given comparator and return a new `Table`.
@@ -1102,6 +1139,20 @@ class Table:
         data_to_json = self._data.copy()
         data_to_json.columns = self._schema.get_column_names()
         data_to_json.to_json(path)
+
+    def to_dict(self) -> dict[str, list[Any]]:
+        """
+        Return a dictionary that maps column names to column values.
+
+        Returns
+        -------
+        data : dict[str, list[Any]]
+            Dictionary representation of the table.
+        """
+        return {
+            column_name: list(self.get_column(column_name))
+            for column_name in self.get_column_names()
+        }
 
     def to_columns(self) -> list[Column]:
         """

--- a/src/safeds/data/tabular/exceptions/_exceptions.py
+++ b/src/safeds/data/tabular/exceptions/_exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class UnknownColumnNameError(KeyError):
     """
     Exception raised for trying to access an invalid column name.

--- a/tests/safeds/data/tabular/containers/_column/test_boxplot.py
+++ b/tests/safeds/data/tabular/containers/_column/test_boxplot.py
@@ -8,23 +8,23 @@ from safeds.data.tabular.exceptions import NonNumericColumnError
 
 def test_boxplot_complex() -> None:
     with pytest.raises(TypeError):  # noqa: PT012
-        table = Table(pd.DataFrame(data={"A": [1, 2, complex(1, -2)]}))
+        table = Table.from_dict({"A": [1, 2, complex(1, -2)]})
         table.get_column("A").boxplot()
 
 
 def test_boxplot_non_numeric() -> None:
-    table = Table(pd.DataFrame(data={"A": [1, 2, "A"]}))
+    table = Table.from_dict({"A": [1, 2, "A"]})
     with pytest.raises(NonNumericColumnError):
         table.get_column("A").boxplot()
 
 
 def test_boxplot_float(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3.5]}))
+    table = Table.from_dict({"A": [1, 2, 3.5]})
     table.get_column("A").boxplot()
 
 
 def test_boxplot_int(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3]}))
+    table = Table.from_dict({"A": [1, 2, 3]})
     table.get_column("A").boxplot()

--- a/tests/safeds/data/tabular/containers/_column/test_boxplot.py
+++ b/tests/safeds/data/tabular/containers/_column/test_boxplot.py
@@ -1,6 +1,5 @@
 import _pytest
 import matplotlib.pyplot as plt
-import pandas as pd
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import NonNumericColumnError

--- a/tests/safeds/data/tabular/containers/_column/test_column.py
+++ b/tests/safeds/data/tabular/containers/_column/test_column.py
@@ -1,16 +1,15 @@
-import pandas as pd
 from safeds.data.tabular.containers import Column
 
 
 def test_from_columns() -> None:
-    column1 = Column("A", pd.Series([1, 4]))
-    column2 = Column("B", pd.Series([2, 5]))
+    column1 = Column("A", [1, 4])
+    column2 = Column("B", [2, 5])
 
     assert column1._type == column2._type
 
 
 def test_from_columns_negative() -> None:
-    column1 = Column("A", pd.Series([1, 4]))
-    column2 = Column("B", pd.Series(["2", "5"]))
+    column1 = Column("A", [1, 4])
+    column2 = Column("B", ["2", "5"])
 
     assert column1._type != column2._type

--- a/tests/safeds/data/tabular/containers/_column/test_column_properties.py
+++ b/tests/safeds/data/tabular/containers/_column/test_column_properties.py
@@ -1,32 +1,31 @@
-import pandas as pd
 from safeds.data.tabular.containers import Column
 
 
 def test_column_property_all_positive() -> None:
-    column = Column("col1", pd.Series([1, 1, 1]))
+    column = Column("col1", [1, 1, 1])
     assert column.all(lambda value: value == 1)
 
 
 def test_column_property_all_negative() -> None:
-    column = Column("col1", pd.Series([1, 2, 1]))
+    column = Column("col1", [1, 2, 1])
     assert not column.all(lambda value: value == 1)
 
 
 def test_column_property_any_positive() -> None:
-    column = Column("col1", pd.Series([1, 2, 1]))
+    column = Column("col1", [1, 2, 1])
     assert column.any(lambda value: value == 1)
 
 
 def test_column_property_any_negative() -> None:
-    column = Column("col1", pd.Series([1, 2, 1]))
+    column = Column("col1", [1, 2, 1])
     assert not column.any(lambda value: value == 3)
 
 
 def test_column_property_none_positive() -> None:
-    column = Column("col1", pd.Series([1, 2, 1]))
+    column = Column("col1", [1, 2, 1])
     assert column.none(lambda value: value == 3)
 
 
 def test_column_property_none_negative() -> None:
-    column = Column("col1", pd.Series([1, 2, 1]))
+    column = Column("col1", [1, 2, 1])
     assert not column.none(lambda value: value == 1)

--- a/tests/safeds/data/tabular/containers/_column/test_correlation_with.py
+++ b/tests/safeds/data/tabular/containers/_column/test_correlation_with.py
@@ -1,26 +1,26 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnLengthMismatchError, NonNumericColumnError
 
 
 def test_correlation_with() -> None:
-    column1 = Column("A", pd.Series([1, 2, 3, 4]))
-    column2 = Column("B", pd.Series([2, 3, 4, 5]))
+    column1 = Column("A",[1, 2, 3, 4])
+    column2 = Column("B",[2, 3, 4, 5])
     actual_corr = column1.correlation_with(column2)
     expected_corr = column1._data.corr(column2._data)
     assert actual_corr == expected_corr
 
 
 def test_correlation_with_raises_if_column_is_not_numeric() -> None:
-    column1 = Column("A", pd.Series([1, 2, 3, 4]))
-    column2 = Column("B", pd.Series(["a", "b", "c", "d"]))
+    column1 = Column("A",[1, 2, 3, 4])
+    column2 = Column("B",["a", "b", "c", "d"])
     with pytest.raises(NonNumericColumnError):
         column1.correlation_with(column2)
 
 
 def test_correlation_with_raises_if_column_lengths_differ() -> None:
-    column1 = Column("A", pd.Series([1, 2, 3, 4]))
-    column2 = Column("B", pd.Series([2]))
+    column1 = Column("A",[1, 2, 3, 4])
+    column2 = Column("B",[2])
     with pytest.raises(ColumnLengthMismatchError):
         column1.correlation_with(column2)

--- a/tests/safeds/data/tabular/containers/_column/test_correlation_with.py
+++ b/tests/safeds/data/tabular/containers/_column/test_correlation_with.py
@@ -1,26 +1,25 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnLengthMismatchError, NonNumericColumnError
 
 
 def test_correlation_with() -> None:
-    column1 = Column("A",[1, 2, 3, 4])
-    column2 = Column("B",[2, 3, 4, 5])
+    column1 = Column("A", [1, 2, 3, 4])
+    column2 = Column("B", [2, 3, 4, 5])
     actual_corr = column1.correlation_with(column2)
     expected_corr = column1._data.corr(column2._data)
     assert actual_corr == expected_corr
 
 
 def test_correlation_with_raises_if_column_is_not_numeric() -> None:
-    column1 = Column("A",[1, 2, 3, 4])
-    column2 = Column("B",["a", "b", "c", "d"])
+    column1 = Column("A", [1, 2, 3, 4])
+    column2 = Column("B", ["a", "b", "c", "d"])
     with pytest.raises(NonNumericColumnError):
         column1.correlation_with(column2)
 
 
 def test_correlation_with_raises_if_column_lengths_differ() -> None:
-    column1 = Column("A",[1, 2, 3, 4])
-    column2 = Column("B",[2])
+    column1 = Column("A", [1, 2, 3, 4])
+    column2 = Column("B", [2])
     with pytest.raises(ColumnLengthMismatchError):
         column1.correlation_with(column2)

--- a/tests/safeds/data/tabular/containers/_column/test_count.py
+++ b/tests/safeds/data/tabular/containers/_column/test_count.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_count.py
+++ b/tests/safeds/data/tabular/containers/_column/test_count.py
@@ -1,6 +1,13 @@
+import pytest
+
 from safeds.data.tabular.containers import Column
 
 
-def test_count_valid() -> None:
-    column = Column("col1", [1, 2, 3, 4, 5])
-    assert column.count() == 5
+@pytest.mark.parametrize(
+    ("column", "expected"),
+    [
+        (Column("col1", [1, 2, 3, 4, 5]), 5),
+    ],
+)
+def test_count_valid(column: Column, expected: int) -> None:
+    assert column.count() == expected

--- a/tests/safeds/data/tabular/containers/_column/test_count_null_values.py
+++ b/tests/safeds/data/tabular/containers/_column/test_count_null_values.py
@@ -4,8 +4,8 @@ from safeds.data.tabular.containers import Table
 
 
 def test_count_null_values_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4, 5], "col2": [None, None, 1, np.nan, np.nan]}))
-    empty_table = Table(pd.DataFrame(data={"col1": []}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4, 5], "col2": [None, None, 1, np.nan, np.nan]})
+    empty_table = Table.from_dict({"col1": []})
     column1 = table.get_column("col1")
     column2 = table.get_column("col2")
     empty_column = empty_table.get_column("col1")

--- a/tests/safeds/data/tabular/containers/_column/test_count_null_values.py
+++ b/tests/safeds/data/tabular/containers/_column/test_count_null_values.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_get_unique_values.py
+++ b/tests/safeds/data/tabular/containers/_column/test_get_unique_values.py
@@ -1,15 +1,20 @@
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 from safeds.data.tabular.containers import Column
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 @pytest.mark.parametrize(
     ("values", "unique_values"),
     [([1, 1, 2, 3], [1, 2, 3]), (["a", "b", "b", "c"], ["a", "b", "c"]), ([], [])],
 )
-def test_get_unique_values(values: list[typing.Any], unique_values: list[typing.Any]) -> None:
+def test_get_unique_values(values: list[Any], unique_values: list[Any]) -> None:
     column: Column = Column("", values)
-    extracted_unique_values: list[typing.Any] = column.get_unique_values()
+    extracted_unique_values = column.get_unique_values()
 
     assert extracted_unique_values == unique_values

--- a/tests/safeds/data/tabular/containers/_column/test_get_value.py
+++ b/tests/safeds/data/tabular/containers/_column/test_get_value.py
@@ -1,17 +1,17 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import IndexOutOfBoundsError
 
 
 def test_get_value_valid() -> None:
-    column = Column("testColumn", pd.Series([0, "1"]))
+    column = Column("testColumn", [0, "1"])
     assert column.get_value(0) == 0
     assert column.get_value(1) == "1"
 
 
 def test_get_value_invalid() -> None:
-    column = Column("testColumn", pd.Series([0, "1"]))
+    column = Column("testColumn", [0, "1"])
     with pytest.raises(IndexOutOfBoundsError):
         column.get_value(-1)
 

--- a/tests/safeds/data/tabular/containers/_column/test_get_value.py
+++ b/tests/safeds/data/tabular/containers/_column/test_get_value.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import IndexOutOfBoundsError
 

--- a/tests/safeds/data/tabular/containers/_column/test_getitem.py
+++ b/tests/safeds/data/tabular/containers/_column/test_getitem.py
@@ -1,18 +1,18 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import IndexOutOfBoundsError
 
 
 def test_getitem_valid() -> None:
-    column = Column("testColumn", pd.Series([0, "1"]))
+    column = Column("testColumn", [0, "1"])
     assert column[0] == 0
     assert column[1] == "1"
 
 
 # noinspection PyStatementEffect
 def test_getitem_invalid() -> None:
-    column = Column("testColumn", pd.Series([0, "1"]))
+    column = Column("testColumn", [0, "1"])
     with pytest.raises(IndexOutOfBoundsError):
         column[-1]
 

--- a/tests/safeds/data/tabular/containers/_column/test_getitem.py
+++ b/tests/safeds/data/tabular/containers/_column/test_getitem.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import IndexOutOfBoundsError
 

--- a/tests/safeds/data/tabular/containers/_column/test_has_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_column/test_has_missing_values.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_has_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_column/test_has_missing_values.py
@@ -1,6 +1,5 @@
-import numpy as np
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 
 
@@ -15,7 +14,7 @@ from safeds.data.tabular.containers import Column
 )
 def test_has_missing_values(values: list, expected: bool) -> None:
     if len(values) == 0:
-        column = Column("A", pd.Series(values, dtype=np.dtype("float64")))
+        column = Column("A", values)
     else:
-        column = Column("A", pd.Series(values))
+        column = Column("A", values)
     assert column.has_missing_values() == expected

--- a/tests/safeds/data/tabular/containers/_column/test_histogram.py
+++ b/tests/safeds/data/tabular/containers/_column/test_histogram.py
@@ -1,6 +1,5 @@
 import _pytest
 import matplotlib.pyplot as plt
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_histogram.py
+++ b/tests/safeds/data/tabular/containers/_column/test_histogram.py
@@ -6,5 +6,5 @@ from safeds.data.tabular.containers import Table
 
 def test_histogram(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3]}))
+    table = Table.from_dict({"A": [1, 2, 3]})
     table.get_column("A").histogram()

--- a/tests/safeds/data/tabular/containers/_column/test_idness.py
+++ b/tests/safeds/data/tabular/containers/_column/test_idness.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnSizeError
 

--- a/tests/safeds/data/tabular/containers/_column/test_idness.py
+++ b/tests/safeds/data/tabular/containers/_column/test_idness.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnSizeError
 
@@ -9,12 +9,12 @@ from safeds.data.tabular.exceptions import ColumnSizeError
     [(["A", "B"], 1), (["A", "A", "A", "B"], 0.5)],
 )
 def test_idness_valid(values: list[str], result: float) -> None:
-    column: Column = Column("test_idness_valid", pd.Series(values))
+    column = Column("test_idness_valid", values)
     idness = column.idness()
     assert idness == result
 
 
 def test_idness_invalid() -> None:
-    column = Column("test_idness_invalid", pd.Series([], dtype=int))
+    column = Column("test_idness_invalid", [])
     with pytest.raises(ColumnSizeError):
         column.idness()

--- a/tests/safeds/data/tabular/containers/_column/test_maximum.py
+++ b/tests/safeds/data/tabular/containers/_column/test_maximum.py
@@ -5,13 +5,13 @@ from safeds.data.tabular.exceptions import NonNumericColumnError
 
 
 def test_maximum_invalid() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1", 2]}))
+    table = Table.from_dict({"col1": ["col1_1", 2]})
     column = table.get_column("col1")
     with pytest.raises(NonNumericColumnError):
         column.maximum()
 
 
 def test_maximum_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4]})
     column = table.get_column("col1")
     assert column.maximum() == 4

--- a/tests/safeds/data/tabular/containers/_column/test_maximum.py
+++ b/tests/safeds/data/tabular/containers/_column/test_maximum.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import NonNumericColumnError

--- a/tests/safeds/data/tabular/containers/_column/test_mean.py
+++ b/tests/safeds/data/tabular/containers/_column/test_mean.py
@@ -5,13 +5,13 @@ from safeds.data.tabular.exceptions import NonNumericColumnError
 
 
 def test_mean_invalid() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1", 2]}))
+    table = Table.from_dict({"col1": ["col1_1", 2]})
     column = table.get_column("col1")
     with pytest.raises(NonNumericColumnError):
         column.mean()
 
 
 def test_mean_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4]})
     column = table.get_column("col1")
     assert column.mean() == 2.5

--- a/tests/safeds/data/tabular/containers/_column/test_mean.py
+++ b/tests/safeds/data/tabular/containers/_column/test_mean.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import NonNumericColumnError

--- a/tests/safeds/data/tabular/containers/_column/test_median.py
+++ b/tests/safeds/data/tabular/containers/_column/test_median.py
@@ -5,19 +5,19 @@ from safeds.data.tabular.exceptions import NonNumericColumnError
 
 
 def test_median_invalid() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1", 2]}))
+    table = Table.from_dict({"col1": ["col1_1", 2]})
     column = table.get_column("col1")
     with pytest.raises(NonNumericColumnError):
         column.median()
 
 
 def test_median_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4, 5]}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4, 5]})
     column = table.get_column("col1")
     assert column.median() == 3
 
 
 def test_median_valid_between_two_values() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4, 5, 6]}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4, 5, 6]})
     column = table.get_column("col1")
     assert column.median() == 3.5

--- a/tests/safeds/data/tabular/containers/_column/test_median.py
+++ b/tests/safeds/data/tabular/containers/_column/test_median.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import NonNumericColumnError

--- a/tests/safeds/data/tabular/containers/_column/test_minimum.py
+++ b/tests/safeds/data/tabular/containers/_column/test_minimum.py
@@ -5,13 +5,13 @@ from safeds.data.tabular.exceptions import NonNumericColumnError
 
 
 def test_minimum_invalid() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1", 2]}))
+    table = Table.from_dict({"col1": ["col1_1", 2]})
     column = table.get_column("col1")
     with pytest.raises(NonNumericColumnError):
         column.minimum()
 
 
 def test_minimum_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4]})
     column = table.get_column("col1")
     assert column.minimum() == 1

--- a/tests/safeds/data/tabular/containers/_column/test_minimum.py
+++ b/tests/safeds/data/tabular/containers/_column/test_minimum.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import NonNumericColumnError

--- a/tests/safeds/data/tabular/containers/_column/test_missing_value_ratio.py
+++ b/tests/safeds/data/tabular/containers/_column/test_missing_value_ratio.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnSizeError
 

--- a/tests/safeds/data/tabular/containers/_column/test_missing_value_ratio.py
+++ b/tests/safeds/data/tabular/containers/_column/test_missing_value_ratio.py
@@ -1,6 +1,5 @@
-import numpy as np
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnSizeError
 
@@ -10,12 +9,12 @@ from safeds.data.tabular.exceptions import ColumnSizeError
     [([1, 2, 3], 0), ([1, 2, 3, None], 1 / 4), ([None, None, None], 1)],
 )
 def test_missing_value_ratio(values: list, expected: float) -> None:
-    column = Column("A", pd.Series(values))
+    column = Column("A", values)
     result = column.missing_value_ratio()
     assert result == expected
 
 
 def test_missing_value_ratio_empty() -> None:
-    column = Column("A", pd.Series([], dtype=np.dtype("float64")))
+    column = Column("A", [])
     with pytest.raises(ColumnSizeError):
         column.missing_value_ratio()

--- a/tests/safeds/data/tabular/containers/_column/test_mode.py
+++ b/tests/safeds/data/tabular/containers/_column/test_mode.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_column/test_mode.py
+++ b/tests/safeds/data/tabular/containers/_column/test_mode.py
@@ -3,18 +3,18 @@ from safeds.data.tabular.containers import Table
 
 
 def test_mode_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3, 4, 3]}))
+    table = Table.from_dict({"col1": [1, 2, 3, 4, 3]})
     column = table.get_column("col1")
     assert column.mode() == [3]
 
 
 def test_mode_valid_str() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["1", "2", "3", "4", "3"]}))
+    table = Table.from_dict({"col1": ["1", "2", "3", "4", "3"]})
     column = table.get_column("col1")
     assert column.mode() == ["3"]
 
 
 def test_mode_valid_list() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["1", "4", "3", "4", "3"]}))
+    table = Table.from_dict({"col1": ["1", "4", "3", "4", "3"]})
     column = table.get_column("col1")
     assert column.mode() == ["3", "4"]

--- a/tests/safeds/data/tabular/containers/_column/test_stability.py
+++ b/tests/safeds/data/tabular/containers/_column/test_stability.py
@@ -1,8 +1,7 @@
-import typing
+from typing import Any
 
-import numpy as np
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnSizeError
 
@@ -15,12 +14,12 @@ from safeds.data.tabular.exceptions import ColumnSizeError
         (["b", "a", "abc", "abc", "abc"], 3 / 5),
     ],
 )
-def test_stability(values: list[typing.Any], expected: float) -> None:
-    column = Column("A", pd.Series(values))
+def test_stability(values: list[Any], expected: float) -> None:
+    column = Column("A", values)
     assert column.stability() == expected
 
 
 def test_stability_error() -> None:
-    column = Column("A", pd.Series([], dtype=np.dtype("float64")))  # Fix warning against unknown type
+    column = Column("A", [])
     with pytest.raises(ColumnSizeError):
         column.stability()

--- a/tests/safeds/data/tabular/containers/_column/test_stability.py
+++ b/tests/safeds/data/tabular/containers/_column/test_stability.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import ColumnSizeError
 

--- a/tests/safeds/data/tabular/containers/_column/test_sum.py
+++ b/tests/safeds/data/tabular/containers/_column/test_sum.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import NonNumericColumnError
 

--- a/tests/safeds/data/tabular/containers/_column/test_sum.py
+++ b/tests/safeds/data/tabular/containers/_column/test_sum.py
@@ -1,15 +1,15 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column
 from safeds.data.tabular.exceptions import NonNumericColumnError
 
 
 def test_sum_valid() -> None:
-    c1 = Column("test", pd.Series([1, 2]))
+    c1 = Column("test", [1, 2])
     assert c1.sum() == 3
 
 
 def test_sum_invalid() -> None:
-    c1 = Column("test", pd.Series([1, "a"]))
+    c1 = Column("test", [1, "a"])
     with pytest.raises(NonNumericColumnError):
         c1.sum()

--- a/tests/safeds/data/tabular/containers/_table/test_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_column.py
@@ -1,6 +1,5 @@
-import pandas as pd
 import pytest
-from _pytest.python_api import raises
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import ColumnSizeError, DuplicateColumnNameError
 from safeds.data.tabular.typing import ColumnType, Integer, String
@@ -14,7 +13,7 @@ from safeds.data.tabular.typing import ColumnType, Integer, String
     ],
 )
 def test_add_column_valid(column: Column, col_type: ColumnType) -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
     table1 = table1.add_column(column)
     assert table1.count_columns() == 3
     assert table1.get_column("col3") == column
@@ -24,12 +23,12 @@ def test_add_column_valid(column: Column, col_type: ColumnType) -> None:
 
 
 def test_add_column_invalid_duplicate_column_name_error() -> None:
-    with raises(DuplicateColumnNameError):
-        table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    with pytest.raises(DuplicateColumnNameError):
         table1 = table1.add_column(Column("col1", ["a", "b", "c"]))
 
 
 def test_add_column_invalid_column_size_error() -> None:
-    with raises(ColumnSizeError):
-        table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    with pytest.raises(ColumnSizeError):
         table1 = table1.add_column(Column("col3", ["a", "b", "c", "d"]))

--- a/tests/safeds/data/tabular/containers/_table/test_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_column.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import ColumnSizeError, DuplicateColumnNameError
 from safeds.data.tabular.typing import ColumnType, Integer, String

--- a/tests/safeds/data/tabular/containers/_table/test_add_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_columns.py
@@ -1,12 +1,11 @@
-import pandas as pd
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.typing import Integer, String
 
 
 def test_add_columns_valid() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    col3 = Column("col3", pd.Series(data=[0, -1, -2]))
-    col4 = Column("col4", pd.Series(data=["a", "b", "c"]))
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    col3 = Column("col3", [0, -1, -2])
+    col4 = Column("col4", ["a", "b", "c"])
     table1 = table1.add_columns([col3, col4])
     assert table1.count_columns() == 4
     assert table1.get_column("col3") == col3
@@ -18,9 +17,9 @@ def test_add_columns_valid() -> None:
 
 
 def test_add_columns_table_valid() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    col3 = Column("col3", pd.Series(data=[0, -1, -2]))
-    col4 = Column("col4", pd.Series(data=["a", "b", "c"]))
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    col3 = Column("col3", [0, -1, -2])
+    col4 = Column("col4", ["a", "b", "c"])
     table2 = Table.from_columns([col3, col4])
     table1 = table1.add_columns(table2)
     assert table1.count_columns() == 4

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -1,5 +1,4 @@
 from _pytest.python_api import raises
-
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.exceptions import SchemaMismatchError
 from safeds.data.tabular.typing import Integer, Schema, String

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -1,13 +1,13 @@
-import pandas as pd
 from _pytest.python_api import raises
+
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.exceptions import SchemaMismatchError
 from safeds.data.tabular.typing import Integer, Schema, String
 
 
 def test_add_row_valid() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    row = Row(pd.Series(data=[5, 6]), table1.schema)
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    row = Row([5, 6], table1.schema)
     table1 = table1.add_row(row)
     assert table1.count_rows() == 4
     assert table1.get_row(3) == row
@@ -15,10 +15,10 @@ def test_add_row_valid() -> None:
 
 
 def test_add_row_invalid() -> None:
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    row = Row(
+        [5, "Hallo"],
+        Schema({"col1": Integer(), "col2": String()}),
+    )
     with raises(SchemaMismatchError):
-        table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-        row = Row(
-            pd.Series(data=[5, "Hallo"]),
-            Schema({"col1": Integer(), "col2": String()}),
-        )
         table1 = table1.add_row(row)

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from safeds.data.tabular.containers import Row, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -3,9 +3,9 @@ from safeds.data.tabular.containers import Row, Table
 
 
 def test_add_rows_valid() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": ["a", "b", "c"], "col2": [1, 2, 4]}))
-    row1 = Row(pd.Series(data=["d", 6]), table1.schema)
-    row2 = Row(pd.Series(data=["e", 8]), table1.schema)
+    table1 = Table.from_dict({"col1": ["a", "b", "c"], "col2": [1, 2, 4]})
+    row1 = Row(["d", 6], table1.schema)
+    row2 = Row(["e", 8], table1.schema)
     table1 = table1.add_rows([row1, row2])
     assert table1.count_rows() == 5
     assert table1.get_row(3) == row1
@@ -15,9 +15,9 @@ def test_add_rows_valid() -> None:
 
 
 def test_add_rows_table_valid() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    row1 = Row(pd.Series(data=[5, 6]), table1.schema)
-    row2 = Row(pd.Series(data=[7, 8]), table1.schema)
+    table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    row1 = Row([5, 6], table1.schema)
+    row2 = Row([7, 8], table1.schema)
     table2 = Table.from_rows([row1, row2])
     table1 = table1.add_rows(table2)
     assert table1.count_rows() == 5

--- a/tests/safeds/data/tabular/containers/_table/test_correlation_heatmap.py
+++ b/tests/safeds/data/tabular/containers/_table/test_correlation_heatmap.py
@@ -1,6 +1,5 @@
 import _pytest
 import matplotlib.pyplot as plt
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_correlation_heatmap.py
+++ b/tests/safeds/data/tabular/containers/_table/test_correlation_heatmap.py
@@ -6,11 +6,11 @@ from safeds.data.tabular.containers import Table
 
 def test_correlation_heatmap_non_numeric(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, "A"], "B": [1, 2, 3]}))
+    table = Table.from_dict({"A": [1, 2, "A"], "B": [1, 2, 3]})
     table.correlation_heatmap()
 
 
 def test_correlation_heatmap(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3.5], "B": [2, 4, 7]}))
+    table = Table.from_dict({"A": [1, 2, 3.5], "B": [2, 4, 7]})
     table.correlation_heatmap()

--- a/tests/safeds/data/tabular/containers/_table/test_count_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_count_columns.py
@@ -1,9 +1,15 @@
-import pandas as pd
+import pytest
+
 from safeds.data.tabular.containers import Table
 
 
-def test_count_columns() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    table2 = Table(pd.DataFrame(data={"col1": []}))
-    assert table1.count_columns() == 2
-    assert table2.count_columns() == 1
+@pytest.mark.parametrize(
+    ("table", "expected"),
+    [
+        (Table.from_dict({}), 0),
+        (Table.from_dict({"col1": []}), 1),
+        (Table.from_dict({"col1": [], "col2": []}), 2),
+    ],
+)
+def test_count_columns(table: Table, expected: int) -> None:
+    assert table.count_columns() == expected

--- a/tests/safeds/data/tabular/containers/_table/test_count_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_count_columns.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_count_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_count_rows.py
@@ -1,9 +1,15 @@
-import pandas as pd
+import pytest
+
 from safeds.data.tabular.containers import Table
 
 
-def test_count_rows() -> None:
-    table1 = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    table2 = Table(pd.DataFrame(data={"col1": []}))
-    assert table1.count_rows() == 3
-    assert table2.count_rows() == 0
+@pytest.mark.parametrize(
+    ("table", "expected"),
+    [
+        (Table.from_dict({}), 0),
+        (Table.from_dict({"col1": [1]}), 1),
+        (Table.from_dict({"col1": [1, 2], "col2": [3, 4]}), 2),
+    ],
+)
+def test_count_rows(table: Table, expected: int) -> None:
+    assert table.count_rows() == expected

--- a/tests/safeds/data/tabular/containers/_table/test_count_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_count_rows.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
@@ -1,10 +1,10 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 
 def test_filter_rows_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
     result_table = table.filter_rows(lambda row: row.get_value("col1") == 1)
     assert result_table.get_column("col1").get_value(0) == 1
     assert result_table.get_column("col2").get_value(1) == 4
@@ -14,6 +14,6 @@ def test_filter_rows_valid() -> None:
 
 # noinspection PyTypeChecker
 def test_filter_rows_invalid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 3], "col2": [1, 1, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 3], "col2": [1, 1, 4]})
     with pytest.raises(TypeError):
         table.filter_rows(table.get_column("col1")._data > table.get_column("col2")._data)

--- a/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.typing import Integer, Schema
 
@@ -12,7 +11,7 @@ from safeds.data.tabular.typing import Integer, Schema
                 Column("A", [1, 4]),
                 Column("B", [2, 5]),
             ],
-            Table([[1, 2], [4, 5]], Schema({"A": Integer(), "B": Integer()}))
+            Table([[1, 2], [4, 5]], Schema({"A": Integer(), "B": Integer()})),
         ),
     ],
 )

--- a/tests/safeds/data/tabular/containers/_table/test_from_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_columns.py
@@ -1,15 +1,20 @@
-import pandas as pd
+import pytest
+
 from safeds.data.tabular.containers import Column, Table
+from safeds.data.tabular.typing import Integer, Schema
 
-from tests.helpers import resolve_resource_path
 
-
-def test_from_columns() -> None:
-    table_expected = Table.from_csv_file(resolve_resource_path("test_column_table.csv"))
-    columns_table: list[Column] = [
-        Column("A", pd.Series([1, 4])),
-        Column("B", pd.Series([2, 5])),
-    ]
-    table_restored: Table = Table.from_columns(columns_table)
-
-    assert table_restored == table_expected
+@pytest.mark.parametrize(
+    ("columns", "expected"),
+    [
+        (
+            [
+                Column("A", [1, 4]),
+                Column("B", [2, 5]),
+            ],
+            Table([[1, 2], [4, 5]], Schema({"A": Integer(), "B": Integer()}))
+        ),
+    ],
+)
+def test_from_columns(columns: list[Column], expected: Table) -> None:
+    assert Table.from_columns(columns) == expected

--- a/tests/safeds/data/tabular/containers/_table/test_get_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_get_column.py
@@ -5,13 +5,13 @@ from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 
 def test_get_column_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1"], "col2": ["col2_1"]}))
+    table = Table.from_dict({"col1": ["col1_1"], "col2": ["col2_1"]})
     assert isinstance(table.get_column("col1"), Column)
     assert table.get_column("col1")._data[0] == pd.Series(data=["col1_1"])[0]
     assert table.get_column("col1")._data[0] == "col1_1"
 
 
 def test_get_column_invalid() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1"], "col2": ["col2_1"]}))
+    table = Table.from_dict({"col1": ["col1_1"], "col2": ["col2_1"]})
     with pytest.raises(UnknownColumnNameError):
         table.get_column("col3")

--- a/tests/safeds/data/tabular/containers/_table/test_get_column_names.py
+++ b/tests/safeds/data/tabular/containers/_table/test_get_column_names.py
@@ -1,13 +1,11 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
-from safeds.data.tabular.typing import Schema
 
 
 def test_get_column_names() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1], "col2": [1]}))
+    table = Table.from_dict({"col1": [1], "col2": [1]})
     assert table.get_column_names() == ["col1", "col2"]
 
 
 def test_get_column_names_empty() -> None:
-    table = Table(pd.DataFrame(), Schema({}))
-    assert not table.get_column_names()
+    table = Table([])
+    assert table.get_column_names() == []

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 

--- a/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_keep_only_columns.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Column, Table
+
+from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 
@@ -8,30 +9,30 @@ class TestKeepOnlyColumns:
         ("table", "column_names", "expected"),
         [
             (
-                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                Table.from_dict({"A": [1], "B": [2]}),
                 [],
-                Table.from_columns([]),
+                Table.from_dict({}),
             ),
             (
-                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                Table.from_dict({"A": [1], "B": [2]}),
                 ["A"],
-                Table.from_columns([Column("A", [1])]),
+                Table.from_dict({"A": [1]}),
             ),
             (
-                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                Table.from_dict({"A": [1], "B": [2]}),
                 ["B"],
-                Table.from_columns([Column("B", [2])]),
+                Table.from_dict({"B": [2]}),
             ),
             (
-                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                Table.from_dict({"A": [1], "B": [2]}),
                 ["A", "B"],
-                Table.from_columns([Column("A", [1]), Column("B", [2])]),
+                Table.from_dict({"A": [1], "B": [2]}),
             ),
             # Related to https://github.com/Safe-DS/Stdlib/issues/115
             (
-                Table.from_columns([Column("A", [1]), Column("B", [2]), Column("C", [3])]),
+                Table.from_dict({"A": [1], "B": [2], "C": [3]}),
                 ["C", "A"],
-                Table.from_columns([Column("C", [3]), Column("A", [1])]),
+                Table.from_dict({"C": [3], "A": [1]}),
             ),
         ],
     )
@@ -40,6 +41,6 @@ class TestKeepOnlyColumns:
         assert transformed_table == expected
 
     def test_should_raise_if_column_does_no_exist(self) -> None:
-        table = Table.from_columns([Column("A", [1]), Column("B", [2])])
+        table = Table.from_dict({"A": [1], "B": [2]})
         with pytest.raises(UnknownColumnNameError):
             table.keep_only_columns(["C"])

--- a/tests/safeds/data/tabular/containers/_table/test_lineplot.py
+++ b/tests/safeds/data/tabular/containers/_table/test_lineplot.py
@@ -1,6 +1,5 @@
 import _pytest
 import matplotlib.pyplot as plt
-import pandas as pd
 import pytest
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError

--- a/tests/safeds/data/tabular/containers/_table/test_lineplot.py
+++ b/tests/safeds/data/tabular/containers/_table/test_lineplot.py
@@ -8,11 +8,11 @@ from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 def test_lineplot(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3], "B": [2, 4, 7]}))
+    table = Table.from_dict({"A": [1, 2, 3], "B": [2, 4, 7]})
     table.lineplot("A", "B")
 
 
 def test_lineplot_wrong_column_name() -> None:
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3], "B": [2, 4, 7]}))
+    table = Table.from_dict({"A": [1, 2, 3], "B": [2, 4, 7]})
     with pytest.raises(UnknownColumnNameError):
         table.lineplot("C", "A")

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_missing_values.py
@@ -1,18 +1,15 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import RealNumber, Schema
 
 
 def test_remove_columns_with_missing_values_valid() -> None:
-    table = Table(
-        pd.DataFrame(
-            data={
-                "col1": [None, None, None, None],
-                "col2": [1, 2, 3, None],
-                "col3": [1, 2, 3, 4],
-                "col4": [2, 3, 1, 4],
-            },
-        ),
+    table = Table.from_dict(
+        {
+            "col1": [None, None, None, None],
+            "col2": [1, 2, 3, None],
+            "col3": [1, 2, 3, 4],
+            "col4": [2, 3, 1, 4],
+        },
     )
     updated_table = table.remove_columns_with_missing_values()
     assert updated_table.get_column_names() == ["col3", "col4"]

--- a/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_non_numerical_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_columns_with_non_numerical_values.py
@@ -1,18 +1,15 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import RealNumber, Schema
 
 
 def test_remove_columns_with_non_numerical_values_valid() -> None:
-    table = Table(
-        pd.DataFrame(
-            data={
-                "col1": ["A", "B", "C", "A"],
-                "col2": ["Test1", "Test1", "Test3", "Test1"],
-                "col3": [1, 2, 3, 4],
-                "col4": [2, 3, 1, 4],
-            },
-        ),
+    table = Table.from_dict(
+        {
+            "col1": ["A", "B", "C", "A"],
+            "col2": ["Test1", "Test1", "Test3", "Test1"],
+            "col3": [1, 2, 3, 4],
+            "col4": [2, 3, 1, 4],
+        },
     )
     updated_table = table.remove_columns_with_non_numerical_values()
     assert updated_table.get_column_names() == ["col3", "col4"]

--- a/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
@@ -1,6 +1,6 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
+
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_duplicate_rows.py
@@ -1,7 +1,6 @@
-import pandas as pd
 import pytest
-from safeds.data.tabular.containers import Table
 
+from safeds.data.tabular.containers import Table
 from tests.helpers import resolve_resource_path
 
 
@@ -13,7 +12,7 @@ from tests.helpers import resolve_resource_path
     ],
 )
 def test_remove_duplicate_rows(path: str) -> None:
-    expected_table = Table(pd.DataFrame(data={"A": [1, 4], "B": [2, 5]}))
+    expected_table = Table.from_dict({"A": [1, 4], "B": [2, 5]})
     table = Table.from_csv_file(resolve_resource_path(path))
     result_table = table.remove_duplicate_rows()
     assert expected_table == result_table

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
@@ -1,18 +1,15 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import RealNumber, Schema
 
 
 def test_remove_rows_with_missing_values_valid() -> None:
-    table = Table(
-        pd.DataFrame(
-            data={
-                "col1": [None, None, "C", "A"],
-                "col2": [None, "Test1", "Test3", "Test1"],
-                "col3": [None, 2, 3, 4],
-                "col4": [None, 3, 1, 4],
-            },
-        ),
+    table = Table.from_dict(
+        {
+            "col1": [None, None, "C", "A"],
+            "col2": [None, "Test1", "Test3", "Test1"],
+            "col3": [None, 2, 3, 4],
+            "col4": [None, 3, 1, 4],
+        },
     )
     updated_table = table.remove_rows_with_missing_values()
     assert updated_table.count_rows() == 2

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.typing import RealNumber, Schema
 

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
@@ -4,14 +4,12 @@ from safeds.data.tabular.typing import RealNumber, Schema
 
 
 def test_remove_rows_with_outliers_no_outliers() -> None:
-    table = Table(
-        pd.DataFrame(
-            data={
-                "col1": ["A", "B", "C"],
-                "col2": [1.0, 2.0, 3.0],
-                "col3": [2, 3, 1],
-            },
-        ),
+    table = Table.from_dict(
+        {
+            "col1": ["A", "B", "C"],
+            "col2": [1.0, 2.0, 3.0],
+            "col3": [2, 3, 1],
+        },
     )
     names = table.get_column_names()
     result = table.remove_rows_with_outliers()
@@ -21,38 +19,34 @@ def test_remove_rows_with_outliers_no_outliers() -> None:
 
 
 def test_remove_rows_with_outliers_with_outliers() -> None:
-    input_ = Table(
-        pd.DataFrame(
-            data={
-                "col1": [
-                    "A",
-                    "B",
-                    "C",
-                    "outlier",
-                    "a",
-                    "a",
-                    "a",
-                    "a",
-                    "a",
-                    "a",
-                    "a",
-                    "a",
-                ],
-                "col2": [1.0, 2.0, 3.0, 4.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, None],
-                "col3": [2, 3, 1, 1_000_000_000, 1, 1, 1, 1, 1, 1, 1, 1],
-            },
-        ),
+    input_ = Table.from_dict(
+        {
+            "col1": [
+                "A",
+                "B",
+                "C",
+                "outlier",
+                "a",
+                "a",
+                "a",
+                "a",
+                "a",
+                "a",
+                "a",
+                "a",
+            ],
+            "col2": [1.0, 2.0, 3.0, 4.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, None],
+            "col3": [2, 3, 1, 1_000_000_000, 1, 1, 1, 1, 1, 1, 1, 1],
+        },
     )
     result = input_.remove_rows_with_outliers()
 
-    expected = Table(
-        pd.DataFrame(
-            data={
-                "col1": ["A", "B", "C", "a", "a", "a", "a", "a", "a", "a", "a"],
-                "col2": [1.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, None],
-                "col3": [2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-            },
-        ),
+    expected = Table.from_dict(
+        {
+            "col1": ["A", "B", "C", "a", "a", "a", "a", "a", "a", "a", "a"],
+            "col2": [1.0, 2.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, None],
+            "col3": [2, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        },
     )
 
     assert result == expected

--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -1,12 +1,11 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import (
     ColumnSizeError,
     DuplicateColumnNameError,
     UnknownColumnNameError,
 )
-
 from tests.helpers import resolve_resource_path
 
 
@@ -21,7 +20,7 @@ def test_replace_valid(column_name: str, path: str) -> None:
     input_table: Table = Table.from_csv_file(resolve_resource_path("test_table_replace_column_input.csv"))
     expected: Table = Table.from_csv_file(resolve_resource_path(path))
 
-    column = Column(column_name, pd.Series(["d", "e", "f"]))
+    column = Column(column_name, ["d", "e", "f"])
 
     result = input_table.replace_column("C", column)
 
@@ -43,7 +42,7 @@ def test_replace_invalid(
     error: type[Exception],
 ) -> None:
     input_table: Table = Table.from_csv_file(resolve_resource_path("test_table_replace_column_input.csv"))
-    column = Column(column_name, pd.Series(column_values))
+    column = Column(column_name, column_values)
 
     with pytest.raises(error):
         input_table.replace_column(old_column_name, column)

--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -1,11 +1,11 @@
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import (
     ColumnSizeError,
     DuplicateColumnNameError,
     UnknownColumnNameError,
 )
+
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_scatterplot.py
+++ b/tests/safeds/data/tabular/containers/_table/test_scatterplot.py
@@ -1,7 +1,6 @@
 import _pytest
 import matplotlib.pyplot as plt
 import pytest
-
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 

--- a/tests/safeds/data/tabular/containers/_table/test_scatterplot.py
+++ b/tests/safeds/data/tabular/containers/_table/test_scatterplot.py
@@ -1,18 +1,18 @@
 import _pytest
 import matplotlib.pyplot as plt
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 
 def test_scatterplot(monkeypatch: _pytest.monkeypatch) -> None:
     monkeypatch.setattr(plt, "show", lambda: None)
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3], "B": [2, 4, 7]}))
+    table = Table.from_dict({"A": [1, 2, 3], "B": [2, 4, 7]})
     table.scatterplot("A", "B")
 
 
 def test_scatterplot_wrong_column_name() -> None:
-    table = Table(pd.DataFrame(data={"A": [1, 2, 3], "B": [2, 4, 7]}))
+    table = Table.from_dict({"A": [1, 2, 3], "B": [2, 4, 7]})
     with pytest.raises(UnknownColumnNameError):
         table.scatterplot("C", "A")

--- a/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_shuffle_rows.py
@@ -1,8 +1,7 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
 def test_shuffle_rows_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1], "col2": [1]}))
+    table = Table.from_dict({"col1": [1], "col2": [1]})
     result_table = table.shuffle_rows()
     assert table == result_table

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -1,12 +1,12 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 
 def test_slice_rows_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    test_table = Table(pd.DataFrame(data={"col1": [1, 2], "col2": [1, 2]}))
-    second_test_table = Table(pd.DataFrame(data={"col1": [1, 1], "col2": [1, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    test_table = Table.from_dict({"col1": [1, 2], "col2": [1, 2]})
+    second_test_table = Table.from_dict({"col1": [1, 1], "col2": [1, 4]})
     new_table = table.slice_rows(0, 2, 1)
     second_new_table = table.slice_rows(0, 3, 2)
     third_new_table = table.slice_rows()
@@ -26,7 +26,7 @@ def test_slice_rows_valid() -> None:
     ],
 )
 def test_slice_rows_invalid(start: int, end: int, step: int) -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
 
     with pytest.raises(ValueError, match="The given index is out of bounds"):
         table.slice_rows(start, end, step)

--- a/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_slice_rows.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_sort_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_columns.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 
 
@@ -20,20 +20,18 @@ from safeds.data.tabular.containers import Column, Table
 )
 def test_sort_columns_valid(query: Callable[[Column, Column], int], col1: int, col2: int, col3: int, col4: int) -> None:
     columns = [
-        Column("col1", pd.Series(data=["A", "B", "C", "A", "D"])),
-        Column("col2", pd.Series(data=["Test1", "Test1", "Test3", "Test1", "Test4"])),
-        Column("col3", pd.Series(data=[1, 2, 3, 4, 5])),
-        Column("col4", pd.Series(data=[2, 3, 1, 4, 6])),
+        Column("col1", ["A", "B", "C", "A", "D"]),
+        Column("col2", ["Test1", "Test1", "Test3", "Test1", "Test4"]),
+        Column("col3", [1, 2, 3, 4, 5]),
+        Column("col4", [2, 3, 1, 4, 6]),
     ]
-    table1 = Table(
-        pd.DataFrame(
-            data={
-                "col2": ["Test1", "Test1", "Test3", "Test1", "Test4"],
-                "col3": [1, 2, 3, 4, 5],
-                "col4": [2, 3, 1, 4, 6],
-                "col1": ["A", "B", "C", "A", "D"],
-            },
-        ),
+    table1 = Table.from_dict(
+        {
+            "col2": ["Test1", "Test1", "Test3", "Test1", "Test4"],
+            "col3": [1, 2, 3, 4, 5],
+            "col4": [2, 3, 1, 4, 6],
+            "col1": ["A", "B", "C", "A", "D"],
+        },
     )
     if query is not None:
         table_sorted = table1.sort_columns(query)

--- a/tests/safeds/data/tabular/containers/_table/test_sort_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_columns.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
@@ -1,19 +1,19 @@
 from collections.abc import Callable
 
 import pytest
-from safeds.data.tabular.containers import Column, Row, Table
+
+from safeds.data.tabular.containers import Row, Table
 
 
 class TestSortRows:
     @pytest.mark.parametrize(
         ("table", "comparator", "expected"),
         [
-            # Activate when https://github.com/Safe-DS/Stdlib/issues/75 is fixed.
-            # ),
+            # Check that it works with an empty table when https://github.com/Safe-DS/Stdlib/issues/75 is fixed.
             (
-                Table.from_columns([Column("col1", [3, 2, 1])]),
+                Table.from_dict({"col1": [3, 2, 1]}),
                 lambda row1, row2: row1["col1"] - row2["col1"],
-                Table.from_columns([Column("col1", [1, 2, 3])]),
+                Table.from_dict({"col1": [1, 2, 3]}),
             ),
         ],
     )
@@ -31,9 +31,9 @@ class TestSortRows:
             # Activate when https://github.com/Safe-DS/Stdlib/issues/75 is fixed.
             # ),
             (
-                Table.from_columns([Column("col1", [3, 2, 1])]),
+                Table.from_dict({"col1": [3, 2, 1]}),
                 lambda row1, row2: row1["col1"] - row2["col1"],
-                Table.from_columns([Column("col1", [3, 2, 1])]),
+                Table.from_dict({"col1": [3, 2, 1]}),
             ),
         ],
     )

--- a/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
@@ -1,7 +1,6 @@
 from collections.abc import Callable
 
 import pytest
-
 from safeds.data.tabular.containers import Row, Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_rows.py
@@ -27,8 +27,7 @@ class TestSortRows:
     @pytest.mark.parametrize(
         ("table", "comparator", "expected"),
         [
-            # Activate when https://github.com/Safe-DS/Stdlib/issues/75 is fixed.
-            # ),
+            # Check that it works with an empty table when https://github.com/Safe-DS/Stdlib/issues/75 is fixed.
             (
                 Table.from_dict({"col1": [3, 2, 1]}),
                 lambda row1, row2: row1["col1"] - row2["col1"],

--- a/tests/safeds/data/tabular/containers/_table/test_split.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split.py
@@ -1,12 +1,12 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Table
 
 
 def test_split_valid() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
-    result_train_table = Table(pd.DataFrame(data={"col1": [1, 2], "col2": [1, 2]}))
-    result_test_table = Table(pd.DataFrame(data={"col1": [1], "col2": [4]}))
+    table = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
+    result_train_table = Table.from_dict({"col1": [1, 2], "col2": [1, 2]})
+    result_test_table = Table.from_dict({"col1": [1], "col2": [4]})
     train_table, test_table = table.split(2 / 3)
     assert result_test_table == test_table
     assert result_train_table == train_table
@@ -22,7 +22,7 @@ def test_split_valid() -> None:
     ],
 )
 def test_split_invalid(percentage_in_first: float) -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": [1, 2, 4]}))
+    table = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
 
     with pytest.raises(ValueError, match="the given percentage is not in range"):
         table.split(percentage_in_first)

--- a/tests/safeds/data/tabular/containers/_table/test_split.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_summary.py
+++ b/tests/safeds/data/tabular/containers/_table/test_summary.py
@@ -1,53 +1,50 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
 def test_summary() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1, 2, 1], "col2": ["a", "b", "c"]}))
+    table = Table.from_dict({"col1": [1, 2, 1], "col2": ["a", "b", "c"]})
 
-    truth = Table(
-        pd.DataFrame(
-            data={
-                "metrics": [
-                    "maximum",
-                    "minimum",
-                    "mean",
-                    "mode",
-                    "median",
-                    "sum",
-                    "variance",
-                    "standard deviation",
-                    "idness",
-                    "stability",
-                    "row count",
-                ],
-                "col1": [
-                    "2",
-                    "1",
-                    str(4.0 / 3),
-                    "[1]",
-                    "1.0",
-                    "4",
-                    str(1.0 / 3),
-                    str(table._data[0].std()),
-                    str(2.0 / 3),
-                    str(2.0 / 3),
-                    "3",
-                ],
-                "col2": [
-                    "-",
-                    "-",
-                    "-",
-                    "['a', 'b', 'c']",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "1.0",
-                    str(1.0 / 3),
-                    "3",
-                ],
-            },
-        ),
+    truth = Table.from_dict(
+        {
+            "metrics": [
+                "maximum",
+                "minimum",
+                "mean",
+                "mode",
+                "median",
+                "sum",
+                "variance",
+                "standard deviation",
+                "idness",
+                "stability",
+                "row count",
+            ],
+            "col1": [
+                "2",
+                "1",
+                str(4.0 / 3),
+                "[1]",
+                "1.0",
+                "4",
+                str(1.0 / 3),
+                str(table._data[0].std()),
+                str(2.0 / 3),
+                str(2.0 / 3),
+                "3",
+            ],
+            "col2": [
+                "-",
+                "-",
+                "-",
+                "['a', 'b', 'c']",
+                "-",
+                "-",
+                "-",
+                "-",
+                "1.0",
+                str(1.0 / 3),
+                "3",
+            ],
+        },
     )
     assert truth == table.summary()

--- a/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
@@ -1,7 +1,7 @@
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import ColumnSizeError, DuplicateColumnNameError
+
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_table_add_column.py
@@ -1,15 +1,14 @@
-import pandas as pd
 import pytest
+
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.exceptions import ColumnSizeError, DuplicateColumnNameError
-
 from tests.helpers import resolve_resource_path
 
 
 def test_table_add_column_valid() -> None:
     input_table = Table.from_csv_file(resolve_resource_path("test_table_add_column_valid_input.csv"))
     expected = Table.from_csv_file(resolve_resource_path("test_table_add_column_valid_output.csv"))
-    column = Column("C", pd.Series(["a", "b", "c"]))
+    column = Column("C", ["a", "b", "c"])
 
     result = input_table.add_column(column)
     assert expected == result
@@ -24,7 +23,7 @@ def test_table_add_column_valid() -> None:
 )
 def test_table_add_column_(column_values: list[str], column_name: str, error: type[Exception]) -> None:
     input_table = Table.from_csv_file(resolve_resource_path("test_table_add_column_valid_input.csv"))
-    column = Column(column_name, pd.Series(column_values))
+    column = Column(column_name, column_values)
 
     with pytest.raises(error):
         input_table.add_column(column)

--- a/tests/safeds/data/tabular/containers/_table/test_to_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_columns.py
@@ -1,6 +1,6 @@
 import pytest
-
 from safeds.data.tabular.containers import Column, Table
+
 from tests.helpers import resolve_resource_path
 
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_columns.py
@@ -1,7 +1,6 @@
-import pandas as pd
 import pytest
-from safeds.data.tabular.containers import Column, Table
 
+from safeds.data.tabular.containers import Column, Table
 from tests.helpers import resolve_resource_path
 
 
@@ -13,6 +12,6 @@ def test_to_columns(values: list[int], name: str, index: int) -> None:
     table = Table.from_csv_file(resolve_resource_path("test_column_table.csv"))
     columns_list: list[Column] = table.to_columns()
 
-    column_expected: Column = Column(name, pd.Series(values, name=name))
+    column_expected: Column = Column(name, values)
 
     assert column_expected == columns_list[index]

--- a/tests/safeds/data/tabular/containers/_table/test_to_csv_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_csv_file.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
 def test_to_csv_file() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1"], "col2": ["col2_1"]}))
+    table = Table.from_dict({"col1": ["col1_1"], "col2": ["col2_1"]})
     with NamedTemporaryFile() as tmp_table_file:
         tmp_table_file.close()
         with Path(tmp_table_file.name).open("w", encoding="utf-8") as tmp_file:

--- a/tests/safeds/data/tabular/containers/_table/test_to_json_file.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_json_file.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
 def test_to_json_file() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1"], "col2": ["col2_1"]}))
+    table = Table.from_dict({"col1": ["col1_1"], "col2": ["col2_1"]})
     with NamedTemporaryFile() as tmp_table_file:
         tmp_table_file.close()
         with Path(tmp_table_file.name).open("w", encoding="utf-8") as tmp_file:

--- a/tests/safeds/data/tabular/containers/_table/test_to_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_rows.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.typing import Integer, Schema, String
 

--- a/tests/safeds/data/tabular/containers/_table/test_to_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_rows.py
@@ -15,9 +15,9 @@ def test_to_rows() -> None:
         },
     )
     rows_expected: list[Row] = [
-        Row(pd.Series([1, 4, "d"], index=["A", "B", "D"], name=0), expected_schema),
-        Row(pd.Series([2, 5, "e"], index=["A", "B", "D"], name=0), expected_schema),
-        Row(pd.Series([3, 6, "f"], index=["A", "B", "D"], name=0), expected_schema),
+        Row([1, 4, "d"], expected_schema),
+        Row([2, 5, "e"], expected_schema),
+        Row([3, 6, "f"], expected_schema),
     ]
 
     rows_is: list[Row] = table.to_rows()

--- a/tests/safeds/data/tabular/containers/test_table.py
+++ b/tests/safeds/data/tabular/containers/test_table.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+import pytest
+
+from safeds.data.tabular.containers import Table
+from safeds.data.tabular.exceptions import ColumnLengthMismatchError
+from safeds.data.tabular.typing import Schema, Integer
+
+
+class TestFromDict:
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            (
+                {},
+                Table([]),
+            ),
+            (
+                {
+                    "a": [1],
+                    "b": [2],
+                },
+                Table([[1, 2]], schema=Schema({"a": Integer(), "b": Integer()})),
+            ),
+        ],
+    )
+    def test_should_create_table_from_dict(self, data: dict[str, Any], expected: Table) -> None:
+        assert Table.from_dict(data) == expected
+
+    def test_should_raise_if_columns_have_different_lengths(self) -> None:
+        with pytest.raises(ColumnLengthMismatchError):
+            Table.from_dict({"a": [1, 2], "b": [3]})
+
+
+class TestToDict:
+    @pytest.mark.parametrize(
+        ("table", "expected"),
+        [
+            (
+                Table([]),
+                {},
+            ),
+            (
+                Table([[1, 2]], schema=Schema({"a": Integer(), "b": Integer()})),
+                {
+                    "a": [1],
+                    "b": [2],
+                },
+            ),
+        ],
+    )
+    def test_should_return_dict_for_table(self, table: Table, expected: dict[str, Any]) -> None:
+        assert table.to_dict() == expected

--- a/tests/safeds/data/tabular/containers/test_table.py
+++ b/tests/safeds/data/tabular/containers/test_table.py
@@ -1,10 +1,9 @@
 from typing import Any
 
 import pytest
-
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import ColumnLengthMismatchError
-from safeds.data.tabular.typing import Schema, Integer
+from safeds.data.tabular.typing import Integer, Schema
 
 
 class TestFromDict:

--- a/tests/safeds/data/tabular/containers/test_tagged_table.py
+++ b/tests/safeds/data/tabular/containers/test_tagged_table.py
@@ -5,13 +5,13 @@ from safeds.data.tabular.exceptions import UnknownColumnNameError
 
 @pytest.fixture()
 def table() -> Table:
-    return Table.from_columns(
-        [
-            Column("A", [1, 4]),
-            Column("B", [2, 5]),
-            Column("C", [3, 6]),
-            Column("T", [0, 1]),
-        ],
+    return Table.from_dict(
+        {
+            "A": [1, 4],
+            "B": [2, 5],
+            "C": [3, 6],
+            "T": [0, 1],
+        },
     )
 
 
@@ -38,7 +38,7 @@ class TestInit:
             table.tag_columns(target_name="A", feature_names=[])
 
     def test_should_raise_if_features_are_empty_implicitly(self, table: Table) -> None:
-        table = Table.from_columns([Column("A", [1, 4])])
+        table = Table.from_dict({"A": [1, 4]})
 
         with pytest.raises(ValueError, match="At least one feature column must be specified."):
             table.tag_columns(target_name="A")
@@ -46,12 +46,12 @@ class TestInit:
 
 class TestFeatures:
     def test_should_return_features(self, tagged_table: TaggedTable) -> None:
-        assert tagged_table.features == Table.from_columns(
-            [
-                Column("A", [1, 4]),
-                Column("B", [2, 5]),
-                Column("C", [3, 6]),
-            ],
+        assert tagged_table.features == Table.from_dict(
+            {
+                "A": [1, 4],
+                "B": [2, 5],
+                "C": [3, 6],
+            },
         )
 
 

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -1,5 +1,6 @@
 import pytest
-from safeds.data.tabular.containers import Column, Table
+
+from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation import Imputer
 from safeds.data.tabular.typing import ImputerStrategy
@@ -7,20 +8,20 @@ from safeds.data.tabular.typing import ImputerStrategy
 
 class TestFit:
     def test_should_raise_if_column_not_found(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1, 3, None]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1, 3, None],
+            },
         )
 
         with pytest.raises(UnknownColumnNameError):
             Imputer(Imputer.Strategy.Constant(0)).fit(table, ["b"])
 
     def test_should_not_change_original_transformer(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1, 3, None]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1, 3, None],
+            },
         )
 
         transformer = Imputer(Imputer.Strategy.Constant(0))
@@ -32,28 +33,28 @@ class TestFit:
 
 class TestTransform:
     def test_should_raise_if_column_not_found(self) -> None:
-        table_to_fit = Table.from_columns(
-            [
-                Column("a", [1, 3, None]),
-            ],
+        table_to_fit = Table.from_dict(
+            {
+                "a": [1, 3, None],
+            },
         )
 
         transformer = Imputer(Imputer.Strategy.Constant(0)).fit(table_to_fit)
 
-        table_to_transform = Table.from_columns(
-            [
-                Column("b", [1, 3, None]),
-            ],
+        table_to_transform = Table.from_dict(
+            {
+                "b": [1, 3, None],
+            },
         )
 
         with pytest.raises(UnknownColumnNameError):
             transformer.transform(table_to_transform)
 
     def test_should_raise_if_not_fitted(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1, 3, None]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1, 3, None],
+            },
         )
 
         transformer = Imputer(Imputer.Strategy.Constant(0))
@@ -68,10 +69,10 @@ class TestIsFitted:
         assert not transformer.is_fitted()
 
     def test_should_return_true_after_fitting(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1, 3, None]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1, 3, None],
+            },
         )
 
         transformer = Imputer(Imputer.Strategy.Mean())
@@ -84,76 +85,75 @@ class TestFitAndTransform:
         ("table", "column_names", "strategy", "expected"),
         [
             (
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, None]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, None],
+                    },
                 ),
                 None,
                 Imputer.Strategy.Constant(0.0),
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 0.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 0.0],
+                    },
                 ),
             ),
             (
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, None]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, None],
+                    },
                 ),
                 None,
                 Imputer.Strategy.Mean(),
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 2.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 2.0],
+                    },
                 ),
             ),
             (
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 1.0, None]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 1.0, None],
+                    },
                 ),
                 None,
                 Imputer.Strategy.Median(),
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 1.0, 1.0]),
-                        Column("a", [1.0, 3.0, 1.0, 1.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 1.0, 1.0],
+                    },
                 ),
             ),
             (
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 3.0, None]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 3.0, None],
+                    },
                 ),
                 None,
                 Imputer.Strategy.Mode(),
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 3.0, 3.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 3.0, 3.0],
+                    },
                 ),
             ),
             (
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, None]),
-                        Column("b", [1.0, 3.0, None]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, None],
+                        "b": [1.0, 3.0, None],
+                    },
                 ),
                 ["a"],
                 Imputer.Strategy.Constant(0.0),
-                Table.from_columns(
-                    [
-                        Column("a", [1.0, 3.0, 0.0]),
-                        Column("b", [1.0, 3.0, None]),
-                    ],
+                Table.from_dict(
+                    {
+                        "a": [1.0, 3.0, 0.0],
+                        "b": [1.0, 3.0, None],
+                    },
                 ),
             ),
         ],
@@ -168,28 +168,28 @@ class TestFitAndTransform:
         assert Imputer(strategy).fit_and_transform(table, column_names) == expected
 
     def test_should_raise_if_strategy_is_mode_but_multiple_values_are_most_frequent(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1, 2, 3, None]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1, 2, 3, None],
+            },
         )
 
         with pytest.raises(IndexError):
             Imputer(Imputer.Strategy.Mode()).fit_and_transform(table)
 
     def test_should_not_change_original_table(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1, None, None]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1, None, None],
+            },
         )
 
         Imputer(strategy=Imputer.Strategy.Constant(1)).fit_and_transform(table)
 
-        expected = Table.from_columns(
-            [
-                Column("a", [1, None, None]),
-            ],
+        expected = Table.from_dict(
+            {
+                "a": [1, None, None],
+            },
         )
 
         assert table == expected

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation import Imputer

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -1,25 +1,26 @@
 import pytest
-from safeds.data.tabular.containers import Column, Table
+
+from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation import LabelEncoder
 
 
 class TestFit:
     def test_should_raise_if_column_not_found(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         with pytest.raises(UnknownColumnNameError):
             LabelEncoder().fit(table, ["col2"])
 
     def test_should_not_change_original_transformer(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = LabelEncoder()
@@ -31,28 +32,28 @@ class TestFit:
 
 class TestTransform:
     def test_should_raise_if_column_not_found(self) -> None:
-        table_to_fit = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table_to_fit = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = LabelEncoder().fit(table_to_fit)
 
-        table_to_transform = Table.from_columns(
-            [
-                Column("col2", ["a", "b", "c"]),
-            ],
+        table_to_transform = Table.from_dict(
+            {
+                "col2": ["a", "b", "c"],
+            },
         )
 
         with pytest.raises(UnknownColumnNameError):
             transformer.transform(table_to_transform)
 
     def test_should_raise_if_not_fitted(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = LabelEncoder()
@@ -67,10 +68,10 @@ class TestIsFitted:
         assert not transformer.is_fitted()
 
     def test_should_return_true_after_fitting(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = LabelEncoder()
@@ -83,31 +84,31 @@ class TestFitAndTransform:
         ("table", "column_names", "expected"),
         [
             (
-                Table.from_columns(
-                    [
-                        Column("col1", ["a", "b", "b", "c"]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1": ["a", "b", "b", "c"],
+                    },
                 ),
                 None,
-                Table.from_columns(
-                    [
-                        Column("col1", [0.0, 1.0, 1.0, 2.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1": [0.0, 1.0, 1.0, 2.0],
+                    },
                 ),
             ),
             (
-                Table.from_columns(
-                    [
-                        Column("col1", ["a", "b", "b", "c"]),
-                        Column("col2", ["a", "b", "b", "c"]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1": ["a", "b", "b", "c"],
+                        "col2": ["a", "b", "b", "c"],
+                    },
                 ),
                 ["col1"],
-                Table.from_columns(
-                    [
-                        Column("col1", [0.0, 1.0, 1.0, 2.0]),
-                        Column("col2", ["a", "b", "b", "c"]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1": [0.0, 1.0, 1.0, 2.0],
+                        "col2": ["a", "b", "b", "c"],
+                    },
                 ),
             ),
         ],
@@ -121,18 +122,18 @@ class TestFitAndTransform:
         assert LabelEncoder().fit_and_transform(table, column_names) == expected
 
     def test_should_not_change_original_table(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         LabelEncoder().fit_and_transform(table)
 
-        expected = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        expected = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         assert table == expected
@@ -142,10 +143,10 @@ class TestInverseTransform:
     @pytest.mark.parametrize(
         "table",
         [
-            Table.from_columns(
-                [
-                    Column("col1", ["a", "b", "b", "c"]),
-                ],
+            Table.from_dict(
+                {
+                    "col1": ["a", "b", "b", "c"],
+                },
             ),
         ],
     )
@@ -155,29 +156,29 @@ class TestInverseTransform:
         assert transformer.inverse_transform(transformer.transform(table)) == table
 
     def test_should_not_change_transformed_table(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = LabelEncoder().fit(table)
         transformed_table = transformer.transform(table)
         transformer.inverse_transform(transformed_table)
 
-        expected = Table.from_columns(
-            [
-                Column("col1", [0.0, 1.0, 2.0]),
-            ],
+        expected = Table.from_dict(
+            {
+                "col1": [0.0, 1.0, 2.0],
+            },
         )
 
         assert transformed_table == expected
 
     def test_should_raise_if_not_fitted(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", [0.0, 1.0, 1.0, 2.0]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": [0.0, 1.0, 1.0, 2.0],
+            },
         )
 
         transformer = LabelEncoder()

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -1,5 +1,4 @@
 import pytest
-
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation import LabelEncoder

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -6,20 +6,20 @@ from safeds.data.tabular.transformation import OneHotEncoder
 
 class TestFit:
     def test_should_raise_if_column_not_found(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         with pytest.raises(UnknownColumnNameError):
             OneHotEncoder().fit(table, ["col2"])
 
     def test_should_not_change_original_transformer(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = OneHotEncoder()
@@ -31,28 +31,28 @@ class TestFit:
 
 class TestTransform:
     def test_should_raise_if_column_not_found(self) -> None:
-        table_to_fit = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table_to_fit = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = OneHotEncoder().fit(table_to_fit)
 
-        table_to_transform = Table.from_columns(
-            [
-                Column("col2", ["a", "b", "c"]),
-            ],
+        table_to_transform = Table.from_dict(
+            {
+                "col2": ["a", "b", "c"],
+            },
         )
 
         with pytest.raises(UnknownColumnNameError):
             transformer.transform(table_to_transform)
 
     def test_should_raise_if_not_fitted(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = OneHotEncoder()
@@ -67,10 +67,10 @@ class TestIsFitted:
         assert not transformer.is_fitted()
 
     def test_should_return_true_after_fitting(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         transformer = OneHotEncoder()
@@ -83,35 +83,35 @@ class TestFitAndTransform:
         ("table", "column_names", "expected"),
         [
             (
-                Table.from_columns(
-                    [
-                        Column("col1", ["a", "b", "b", "c"]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1": ["a", "b", "b", "c"],
+                    },
                 ),
                 None,
-                Table.from_columns(
-                    [
-                        Column("col1_a", [1.0, 0.0, 0.0, 0.0]),
-                        Column("col1_b", [0.0, 1.0, 1.0, 0.0]),
-                        Column("col1_c", [0.0, 0.0, 0.0, 1.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1_a": [1.0, 0.0, 0.0, 0.0],
+                        "col1_b": [0.0, 1.0, 1.0, 0.0],
+                        "col1_c": [0.0, 0.0, 0.0, 1.0],
+                    },
                 ),
             ),
             (
-                Table.from_columns(
-                    [
-                        Column("col1", ["a", "b", "b", "c"]),
-                        Column("col2", ["a", "b", "b", "c"]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col1": ["a", "b", "b", "c"],
+                        "col2": ["a", "b", "b", "c"],
+                    },
                 ),
                 ["col1"],
-                Table.from_columns(
-                    [
-                        Column("col2", ["a", "b", "b", "c"]),
-                        Column("col1_a", [1.0, 0.0, 0.0, 0.0]),
-                        Column("col1_b", [0.0, 1.0, 1.0, 0.0]),
-                        Column("col1_c", [0.0, 0.0, 0.0, 1.0]),
-                    ],
+                Table.from_dict(
+                    {
+                        "col2": ["a", "b", "b", "c"],
+                        "col1_a": [1.0, 0.0, 0.0, 0.0],
+                        "col1_b": [0.0, 1.0, 1.0, 0.0],
+                        "col1_c": [0.0, 0.0, 0.0, 1.0],
+                    },
                 ),
             ),
         ],
@@ -125,18 +125,18 @@ class TestFitAndTransform:
         assert OneHotEncoder().fit_and_transform(table, column_names) == expected
 
     def test_should_not_change_original_table(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         OneHotEncoder().fit_and_transform(table)
 
-        expected = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "c"]),
-            ],
+        expected = Table.from_dict(
+            {
+                "col1": ["a", "b", "c"],
+            },
         )
 
         assert table == expected
@@ -146,10 +146,10 @@ class TestInverseTransform:
     @pytest.mark.parametrize(
         "table",
         [
-            Table.from_columns(
-                [
-                    Column("col1", ["a", "b", "b", "c"]),
-                ],
+            Table.from_dict(
+                {
+                    "col1": ["a", "b", "b", "c"],
+                },
             ),
         ],
     )
@@ -159,33 +159,33 @@ class TestInverseTransform:
         assert transformer.inverse_transform(transformer.transform(table)) == table
 
     def test_should_not_change_transformed_table(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("col1", ["a", "b", "b", "c"]),
-            ],
+        table = Table.from_dict(
+            {
+                "col1": ["a", "b", "b", "c"],
+            },
         )
 
         transformer = OneHotEncoder().fit(table)
         transformed_table = transformer.transform(table)
         transformer.inverse_transform(transformed_table)
 
-        expected = Table.from_columns(
-            [
-                Column("col1_a", [1.0, 0.0, 0.0, 0.0]),
-                Column("col1_b", [0.0, 1.0, 1.0, 0.0]),
-                Column("col1_c", [0.0, 0.0, 0.0, 1.0]),
-            ],
+        expected = Table.from_dict(
+            {
+                "col1_a": [1.0, 0.0, 0.0, 0.0],
+                "col1_b": [0.0, 1.0, 1.0, 0.0],
+                "col1_c": [0.0, 0.0, 0.0, 1.0],
+            },
         )
 
         assert transformed_table == expected
 
     def test_should_raise_if_not_fitted(self) -> None:
-        table = Table.from_columns(
-            [
-                Column("a", [1.0, 0.0, 0.0, 0.0]),
-                Column("b", [0.0, 1.0, 1.0, 0.0]),
-                Column("c", [0.0, 0.0, 0.0, 1.0]),
-            ],
+        table = Table.from_dict(
+            {
+                "a": [1.0, 0.0, 0.0, 0.0],
+                "b": [0.0, 1.0, 1.0, 0.0],
+                "c": [0.0, 0.0, 0.0, 1.0],
+            },
         )
 
         transformer = OneHotEncoder()

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -1,5 +1,5 @@
 import pytest
-from safeds.data.tabular.containers import Column, Table
+from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownColumnNameError
 from safeds.data.tabular.transformation import OneHotEncoder
 

--- a/tests/safeds/data/tabular/typing/_schema/test__str__.py
+++ b/tests/safeds/data/tabular/typing/_schema/test__str__.py
@@ -1,7 +1,6 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
 def test__str__() -> None:
-    table = Table(pd.DataFrame(data={"col1": ["col1_1"], "col2": [1]}))
+    table = Table.from_dict({"col1": ["col1_1"], "col2": [1]})
     assert str(table.schema) == "TableSchema:\nColumn Count: 2\nColumns:\n    col1: String\n    col2: Integer\n"

--- a/tests/safeds/data/tabular/typing/_schema/test_get_column_index_by_name.py
+++ b/tests/safeds/data/tabular/typing/_schema/test_get_column_index_by_name.py
@@ -1,8 +1,7 @@
-import pandas as pd
 from safeds.data.tabular.containers import Table
 
 
 def test_get_column_index_by_name() -> None:
-    table = Table(pd.DataFrame(data={"col1": [1], "col2": [2]}))
+    table = Table.from_dict({"col1": [1], "col2": [2]})
     assert table.schema._get_column_index_by_name("col1") == 0
     assert table.schema._get_column_index_by_name("col2") == 1

--- a/tests/safeds/ml/classification/test_classifier.py
+++ b/tests/safeds/ml/classification/test_classifier.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-
 from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.ml.classification import (
     AdaBoost,
@@ -178,7 +177,7 @@ class TestAccuracy:
             {
                 "predicted": [1, 2, 3, 4],
                 "expected": [1, 2, 3, 3],
-            }
+            },
         ).tag_columns(target_name="expected")
 
         assert DummyClassifier().accuracy(table) == 0.75
@@ -188,8 +187,7 @@ class TestAccuracy:
             {
                 "predicted": ["1", "2", "3", "4"],
                 "expected": [1, 2, 3, 3],
-            }
-        ).tag_columns(
-            target_name="expected")
+            },
+        ).tag_columns(target_name="expected")
 
         assert DummyClassifier().accuracy(table) == 0.0

--- a/tests/safeds/ml/classification/test_classifier.py
+++ b/tests/safeds/ml/classification/test_classifier.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import pytest
-from safeds.data.tabular.containers import Column, Table, TaggedTable
+
+from safeds.data.tabular.containers import Table, TaggedTable
 from safeds.ml.classification import (
     AdaBoost,
     Classifier,
@@ -43,25 +43,25 @@ def classifiers() -> list[Classifier]:
 
 @pytest.fixture()
 def valid_data() -> TaggedTable:
-    return Table.from_columns(
-        [
-            Column("id", [1, 4]),
-            Column("feat1", [2, 5]),
-            Column("feat2", [3, 6]),
-            Column("target", [0, 1]),
-        ],
+    return Table.from_dict(
+        {
+            "id": [1, 4],
+            "feat1": [2, 5],
+            "feat2": [3, 6],
+            "target": [0, 1],
+        },
     ).tag_columns(target_name="target", feature_names=["feat1", "feat2"])
 
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    return Table.from_columns(
-        [
-            Column("id", [1, 4]),
-            Column("feat1", ["a", 5]),
-            Column("feat2", [3, 6]),
-            Column("target", [0, 1]),
-        ],
+    return Table.from_dict(
+        {
+            "id": [1, 4],
+            "feat1": ["a", 5],
+            "feat2": [3, 6],
+            "target": [0, 1],
+        },
     ).tag_columns(target_name="target", feature_names=["feat1", "feat2"])
 
 
@@ -174,15 +174,22 @@ class DummyClassifier(Classifier):
 
 class TestAccuracy:
     def test_with_same_type(self) -> None:
-        c1 = Column("predicted", [1, 2, 3, 4])
-        c2 = Column("expected", [1, 2, 3, 3])
-        table = Table.from_columns([c1, c2]).tag_columns(target_name="expected")
+        table = Table.from_dict(
+            {
+                "predicted": [1, 2, 3, 4],
+                "expected": [1, 2, 3, 3],
+            }
+        ).tag_columns(target_name="expected")
 
         assert DummyClassifier().accuracy(table) == 0.75
 
     def test_with_different_types(self) -> None:
-        c1 = Column("predicted", pd.Series(data=["1", "2", "3", "4"]))
-        c2 = Column("expected", pd.Series(data=[1, 2, 3, 3]))
-        table = Table.from_columns([c1, c2]).tag_columns(target_name="expected")
+        table = Table.from_dict(
+            {
+                "predicted": ["1", "2", "3", "4"],
+                "expected": [1, 2, 3, 3],
+            }
+        ).tag_columns(
+            target_name="expected")
 
         assert DummyClassifier().accuracy(table) == 0.0

--- a/tests/safeds/ml/regression/test_regressor.py
+++ b/tests/safeds/ml/regression/test_regressor.py
@@ -60,25 +60,25 @@ def regressors() -> list[Regressor]:
 
 @pytest.fixture()
 def valid_data() -> TaggedTable:
-    return Table.from_columns(
-        [
-            Column("id", [1, 4]),
-            Column("feat1", [2, 5]),
-            Column("feat2", [3, 6]),
-            Column("target", [0, 1]),
-        ],
+    return Table.from_dict(
+        {
+            "id": [1, 4],
+            "feat1": [2, 5],
+            "feat2": [3, 6],
+            "target": [0, 1],
+        },
     ).tag_columns(target_name="target", feature_names=["feat1", "feat2"])
 
 
 @pytest.fixture()
 def invalid_data() -> TaggedTable:
-    return Table.from_columns(
-        [
-            Column("id", [1, 4]),
-            Column("feat1", ["a", 5]),
-            Column("feat2", [3, 6]),
-            Column("target", [0, 1]),
-        ],
+    return Table.from_dict(
+        {
+            "id": [1, 4],
+            "feat1": ["a", 5],
+            "feat2": [3, 6],
+            "target": [0, 1],
+        },
     ).tag_columns(target_name="target", feature_names=["feat1", "feat2"])
 
 
@@ -201,11 +201,12 @@ class TestMeanAbsoluteError:
         ],
     )
     def test_valid_data(self, predicted: list[float], expected: list[float], result: float) -> None:
-        predicted_column = Column("predicted", predicted)
-        expected_column = Column("expected", expected)
-        table = Table.from_columns([predicted_column, expected_column]).tag_columns(
-            target_name="expected",
-        )
+        table = Table.from_dict(
+            {
+                "predicted": predicted,
+                "expected": expected,
+            }
+        ).tag_columns(target_name="expected",)
 
         assert DummyRegressor().mean_absolute_error(table) == result
 
@@ -216,11 +217,12 @@ class TestMeanSquaredError:
         [([1, 2], [1, 2], 0), ([0, 0], [1, 1], 1), ([1, 1, 1], [2, 2, 11], 34)],
     )
     def test_valid_data(self, predicted: list[float], expected: list[float], result: float) -> None:
-        predicted_column = Column("predicted", predicted)
-        expected_column = Column("expected", expected)
-        table = Table.from_columns([predicted_column, expected_column]).tag_columns(
-            target_name="expected",
-        )
+        table = Table.from_dict(
+            {
+                "predicted": predicted,
+                "expected": expected
+            }
+        ).tag_columns(target_name="expected",)
 
         assert DummyRegressor().mean_squared_error(table) == result
 

--- a/tests/safeds/ml/regression/test_regressor.py
+++ b/tests/safeds/ml/regression/test_regressor.py
@@ -205,8 +205,10 @@ class TestMeanAbsoluteError:
             {
                 "predicted": predicted,
                 "expected": expected,
-            }
-        ).tag_columns(target_name="expected",)
+            },
+        ).tag_columns(
+            target_name="expected",
+        )
 
         assert DummyRegressor().mean_absolute_error(table) == result
 
@@ -217,12 +219,9 @@ class TestMeanSquaredError:
         [([1, 2], [1, 2], 0), ([0, 0], [1, 1], 1), ([1, 1, 1], [2, 2, 11], 34)],
     )
     def test_valid_data(self, predicted: list[float], expected: list[float], result: float) -> None:
-        table = Table.from_dict(
-            {
-                "predicted": predicted,
-                "expected": expected
-            }
-        ).tag_columns(target_name="expected",)
+        table = Table.from_dict({"predicted": predicted, "expected": expected}).tag_columns(
+            target_name="expected",
+        )
 
         assert DummyRegressor().mean_squared_error(table) == result
 


### PR DESCRIPTION
Closes #197.

### Summary of Changes

Added two new methods to `Table`:
* `from_dict` can create a `Table` from a `dict`
* `to_dict` can convert a `Table` to a `dict`