### PR TITLE
feat: dataframe interchange protocol

### DIFF
--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1195,9 +1195,9 @@ class Table:
     # Dataframe interchange protocol
     # ------------------------------------------------------------------------------------------------------------------
 
-    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
+    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):  # type: ignore[no-untyped-def]
         """
-        Returns a DataFrame exchange object that conforms to the dataframe interchange protocol.
+        Return a DataFrame exchange object that conforms to the dataframe interchange protocol.
 
         Generally, there is no reason to call this method directly. The dataframe interchange protocol is designed to
         allow libraries to consume tabular data from different sources, such as `pandas` or `polars`. If you still

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -854,7 +854,7 @@ class Table:
     def sort_columns(
         self,
         comparator: Callable[[Column, Column], int] = lambda col1, col2: (col1.name > col2.name)
-                                                                         - (col1.name < col2.name),
+        - (col1.name < col2.name),
     ) -> Table:
         """
         Sort the columns of a `Table` with the given comparator and return a new `Table`.

--- a/tests/safeds/data/tabular/containers/test_table.py
+++ b/tests/safeds/data/tabular/containers/test_table.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 import pytest
+from pandas.core.interchange.from_dataframe import from_dataframe
+
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import ColumnLengthMismatchError
 from safeds.data.tabular.typing import Integer, Schema
@@ -50,3 +52,27 @@ class TestToDict:
     )
     def test_should_return_dict_for_table(self, table: Table, expected: dict[str, Any]) -> None:
         assert table.to_dict() == expected
+
+
+class TestDataframe:
+    @pytest.mark.parametrize(
+        "table",
+        [
+            Table([]),
+            Table.from_dict({"a": [1, 2], "b": [3, 4]}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ]
+    )
+    def test_can_restore_table_from_exchange_object(self, table: Table) -> None:
+        exchange_object = table.__dataframe__()
+        restored = Table(from_dataframe(exchange_object))
+
+        assert restored == table
+
+    def test_should_raise_if_allow_copy_is_false(self) -> None:
+        table = Table.from_dict({})
+        with pytest.raises(NotImplementedError, match="`allow_copy` must be True"):
+            table.__dataframe__(allow_copy=False)

--- a/tests/safeds/data/tabular/containers/test_table.py
+++ b/tests/safeds/data/tabular/containers/test_table.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 from pandas.core.interchange.from_dataframe import from_dataframe
-
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.exceptions import ColumnLengthMismatchError
 from safeds.data.tabular.typing import Integer, Schema
@@ -64,7 +63,7 @@ class TestDataframe:
         ids=[
             "empty",
             "non-empty",
-        ]
+        ],
     )
     def test_can_restore_table_from_exchange_object(self, table: Table) -> None:
         exchange_object = table.__dataframe__()


### PR DESCRIPTION
Closes #199.

### Summary of Changes

* Add a method `__dataframe__` to `Table` to support the [dataframe interchange protocol](https://data-apis.org/dataframe-protocol/latest/index.html#).
