### PR TITLE
refactor: keep column names of `DataFrame` inside `Table`

### DIFF
--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -30,22 +30,22 @@ class Row:
         self._data: pd.Series = data if isinstance(data, pd.Series) else pd.Series(data)
         self._data = self._data.reset_index(drop=True)
 
-        self.schema: Schema
+        self._schema: Schema
         if schema is not None:
-            self.schema = schema
+            self._schema = schema
         else:
             column_names = [f"column_{i}" for i in range(len(self._data))]
             dataframe = self._data.to_frame().T
             dataframe.columns = column_names
             # noinspection PyProtectedMember
-            self.schema = Schema._from_dataframe(dataframe)
+            self._schema = Schema._from_dataframe(dataframe)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Row):
             return NotImplemented
         if self is other:
             return True
-        return self.schema == other.schema and self._data.equals(other._data)
+        return self._schema == other._schema and self._data.equals(other._data)
 
     def __getitem__(self, column_name: str) -> Any:
         return self.get_value(column_name)
@@ -73,6 +73,22 @@ class Row:
         return tmp.__str__()
 
     # ------------------------------------------------------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------------------------------------------------------
+
+    @property
+    def schema(self) -> Schema:
+        """
+        Return the schema of the row.
+
+        Returns
+        -------
+        schema : Schema
+            The schema.
+        """
+        return self._schema
+
+    # ------------------------------------------------------------------------------------------------------------------
     # Getters
     # ------------------------------------------------------------------------------------------------------------------
 
@@ -90,10 +106,10 @@ class Row:
         value :
             The value of the column.
         """
-        if not self.schema.has_column(column_name):
+        if not self._schema.has_column(column_name):
             raise UnknownColumnNameError([column_name])
         # noinspection PyProtectedMember
-        return self._data[self.schema._get_column_index_by_name(column_name)]
+        return self._data[self._schema._get_column_index_by_name(column_name)]
 
     def has_column(self, column_name: str) -> bool:
         """
@@ -111,7 +127,7 @@ class Row:
         contains : bool
             True, if row contains the column.
         """
-        return self.schema.has_column(column_name)
+        return self._schema.has_column(column_name)
 
     def get_column_names(self) -> list[str]:
         """
@@ -124,7 +140,7 @@ class Row:
         column_names : list[str]
             The column names.
         """
-        return self.schema.get_column_names()
+        return self._schema.get_column_names()
 
     def get_type_of_column(self, column_name: str) -> ColumnType:
         """
@@ -147,7 +163,7 @@ class Row:
         ColumnNameError
             If the specified target column name does not exist.
         """
-        return self.schema.get_type_of_column(column_name)
+        return self._schema.get_type_of_column(column_name)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Information

--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -159,7 +159,8 @@ class Imputer(TableTransformer):
 
         data = table._data.copy()
         data[self._column_names] = pd.DataFrame(
-            self._wrapped_transformer.transform(data[self._column_names]), columns=self._column_names,
+            self._wrapped_transformer.transform(data[self._column_names]),
+            columns=self._column_names,
         )
         return Table(data, table.schema)
 

--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -118,11 +118,9 @@ class Imputer(TableTransformer):
                 if len(table.get_column(name).mode()) > 1:
                     raise IndexError("There are multiple most frequent values in a column given for the Imputer")
 
-        indices = [table.schema._get_column_index_by_name(name) for name in column_names]
-
         wrapped_transformer = sk_SimpleImputer()
         self._strategy._augment_imputer(wrapped_transformer)
-        wrapped_transformer.fit(table._data[indices])
+        wrapped_transformer.fit(table._data[column_names])
 
         result = Imputer(self._strategy)
         result._wrapped_transformer = wrapped_transformer
@@ -160,8 +158,10 @@ class Imputer(TableTransformer):
             raise UnknownColumnNameError(list(missing_columns))
 
         data = table._data.copy()
-        indices = [table.schema._get_column_index_by_name(name) for name in self._column_names]
-        data[indices] = pd.DataFrame(self._wrapped_transformer.transform(data[indices]), columns=indices)
+        data[self._column_names] = pd.DataFrame(
+            self._wrapped_transformer.transform(data[self._column_names]),
+            columns=self._column_names
+        )
         return Table(data, table.schema)
 
     def is_fitted(self) -> bool:

--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -159,8 +159,7 @@ class Imputer(TableTransformer):
 
         data = table._data.copy()
         data[self._column_names] = pd.DataFrame(
-            self._wrapped_transformer.transform(data[self._column_names]),
-            columns=self._column_names
+            self._wrapped_transformer.transform(data[self._column_names]), columns=self._column_names,
         )
         return Table(data, table.schema)
 

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -50,10 +50,8 @@ class LabelEncoder(InvertibleTableTransformer):
             if len(missing_columns) > 0:
                 raise UnknownColumnNameError(list(missing_columns))
 
-        indices = [table.schema._get_column_index_by_name(name) for name in column_names]
-
         wrapped_transformer = sk_OrdinalEncoder()
-        wrapped_transformer.fit(table._data[indices])
+        wrapped_transformer.fit(table._data[column_names])
 
         result = LabelEncoder()
         result._wrapped_transformer = wrapped_transformer

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -10,7 +10,7 @@ def test_add_row_valid() -> None:
     table1 = table1.add_row(row)
     assert table1.count_rows() == 4
     assert table1.get_row(3) == row
-    assert table1.schema == row.schema
+    assert table1.schema == row._schema
 
 
 def test_add_row_invalid() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -9,8 +9,8 @@ def test_add_rows_valid() -> None:
     assert table1.count_rows() == 5
     assert table1.get_row(3) == row1
     assert table1.get_row(4) == row2
-    assert table1.schema == row1.schema
-    assert table1.schema == row2.schema
+    assert table1.schema == row1._schema
+    assert table1.schema == row2._schema
 
 
 def test_add_rows_table_valid() -> None:
@@ -22,5 +22,5 @@ def test_add_rows_table_valid() -> None:
     assert table1.count_rows() == 5
     assert table1.get_row(3) == row1
     assert table1.get_row(4) == row2
-    assert table1.schema == row1.schema
-    assert table1.schema == row2.schema
+    assert table1.schema == row1._schema
+    assert table1.schema == row2._schema

--- a/tests/safeds/data/tabular/containers/_table/test_summary.py
+++ b/tests/safeds/data/tabular/containers/_table/test_summary.py
@@ -27,7 +27,7 @@ def test_summary() -> None:
                 "1.0",
                 "4",
                 str(1.0 / 3),
-                str(table._data[0].std()),
+                str(table._data["col1"].std()),
                 str(2.0 / 3),
                 str(2.0 / 3),
                 "3",

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -19,7 +19,7 @@ class TestInit:
         ],
     )
     def test_should_use_the_schema_if_passed(self, row: Row, expected: Schema) -> None:
-        assert row.schema == expected
+        assert row._schema == expected
 
     @pytest.mark.parametrize(
         ("row", "expected"),
@@ -29,7 +29,7 @@ class TestInit:
         ],
     )
     def test_should_infer_the_schema_if_not_passed(self, row: Row, expected: Schema) -> None:
-        assert row.schema == expected
+        assert row._schema == expected
 
 
 class TestEq:


### PR DESCRIPTION
Closes #202.

### Summary of Changes

* Explicitly set the names of the columns in the `DataFrame` that is contained in a `Table`
