### PR TITLE
feat: back `Row` by a `polars.DataFrame`

### DIFF
--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -14,9 +14,7 @@ if TYPE_CHECKING:
 
 
 class Row:
-    """
-    A row is a collection of values, where each value is associated with a column name.
-    """
+    """A row is a collection of values, where each value is associated with a column name."""
 
     # ------------------------------------------------------------------------------------------------------------------
     # Creation

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import pandas as pd
 import polars as pl
-from IPython.core.display_functions import DisplayHandle, display
 
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 from safeds.data.tabular.typing import ColumnType, Schema
@@ -211,16 +209,14 @@ class Row:
     # IPython integration
     # ------------------------------------------------------------------------------------------------------------------
 
-    def _ipython_display_(self) -> DisplayHandle:
+    def _repr_html_(self) -> str:
         """
-        Return a display object for the column to be used in Jupyter Notebooks.
+        Return an HTML representation of the row.
 
         Returns
         -------
-        output : DisplayHandle
-            Output object.
+        output : str
+            The generated HTML.
         """
-        tmp = self._data.to_pandas()
-
-        with pd.option_context("display.max_rows", tmp.shape[0], "display.max_columns", tmp.shape[1]):
-            return display(tmp)
+        # noinspection PyProtectedMember
+        return self._data._repr_html_()

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -110,7 +110,6 @@ class Row:
         >>> row["a"]
         1
         """
-
         return self.get_value(column_name)
 
     def __iter__(self) -> Iterator[Any]:

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -90,14 +90,18 @@ class Row:
         return len(self._data)
 
     def __repr__(self) -> str:
-        tmp = self._data.to_frame().T
-        tmp.columns = self.get_column_names()
-        return tmp.__repr__()
+        return f"Row({str(self)})"
 
     def __str__(self) -> str:
-        tmp = self._data.to_frame().T
-        tmp.columns = self.get_column_names()
-        return tmp.__str__()
+        match len(self):
+            case 0:
+                return "{}"
+            case 1:
+                return str(self.to_dict())
+            case _:
+                lines = (f"    {name!r}: {value!r}" for name, value in self.to_dict().items())
+                joined = ",\n".join(lines)
+                return f"{{\n{joined}\n}}"
 
     # ------------------------------------------------------------------------------------------------------------------
     # Properties

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -12,7 +12,16 @@ if TYPE_CHECKING:
 
 
 class Row:
-    """A row is a collection of values, where each value is associated with a column name."""
+    """
+    A row is a collection of values, where each value is associated with a column name.
+
+    To create a row manually, use the static method [from_dict][safeds.data.tabular.containers._row.Row.from_dict].
+
+    Examples
+    --------
+    >>> from safeds.data.tabular.containers import Row
+    >>> row = Row.from_dict({"a": 1, "b": 2})
+    """
 
     # ------------------------------------------------------------------------------------------------------------------
     # Creation
@@ -32,6 +41,11 @@ class Row:
         -------
         row : Row
             The generated row.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
         """
         return Row(pl.DataFrame(data))
 
@@ -40,6 +54,20 @@ class Row:
     # ------------------------------------------------------------------------------------------------------------------
 
     def __init__(self, data: pl.DataFrame, schema: Schema | None = None):
+        """
+        Initialize a row from a `polars.DataFrame`.
+
+        **Do not use this method directly.** It is not part of the public interface and may change in the future
+        without a major version bump. Use the static method
+        [from_dict][safeds.data.tabular.containers._row.Row.from_dict] instead.
+
+        Parameters
+        ----------
+        data : polars.DataFrame
+            The data.
+        schema : Schema | None
+            The schema. If None, the schema is inferred from the data.
+        """
         self._data: pl.DataFrame = data
 
         self._schema: Schema
@@ -57,12 +85,53 @@ class Row:
         return self._schema == other._schema and self._data.frame_equal(other._data)
 
     def __getitem__(self, column_name: str) -> Any:
+        """
+        Return the value of a specified column.
+
+        Parameters
+        ----------
+        column_name : str
+            The column name.
+
+        Returns
+        -------
+        value : Any
+            The value of the column.
+
+        Raises
+        ------
+        UnknownColumnNameError
+            If the row does not contain the specified column.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row["a"]
+        1
+        """
+
         return self.get_value(column_name)
 
     def __iter__(self) -> Iterator[Any]:
         return iter(self.get_column_names())
 
     def __len__(self) -> int:
+        """
+        Return the number of columns in this row.
+
+        Returns
+        -------
+        count : int
+            The number of columns.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> len(row)
+        2
+        """
         return self._data.shape[1]
 
     def __repr__(self) -> str:
@@ -92,6 +161,12 @@ class Row:
         -------
         schema : Schema
             The schema.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> schema = row.schema
         """
         return self._schema
 
@@ -110,13 +185,20 @@ class Row:
 
         Returns
         -------
-        value :
+        value : Any
             The value of the column.
 
         Raises
         ------
         UnknownColumnNameError
             If the row does not contain the specified column.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row.get_value("a")
+        1
         """
         if not self.has_column(column_name):
             raise UnknownColumnNameError([column_name])
@@ -127,8 +209,6 @@ class Row:
         """
         Return whether the row contains a given column.
 
-        Alias for self.schema.hasColumn(column_name: str) -> bool.
-
         Parameters
         ----------
         column_name : str
@@ -136,21 +216,36 @@ class Row:
 
         Returns
         -------
-        contains : bool
+        has_column : bool
             True, if row contains the column.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row.has_column("a")
+        True
+
+        >>> row.has_column("c")
+        False
         """
         return self._schema.has_column(column_name)
 
     def get_column_names(self) -> list[str]:
         """
-        Return a list of all column names saved in this schema.
-
-        Alias for self.schema.get_column_names() -> list[str].
+        Return a list of all column names in the row.
 
         Returns
         -------
         column_names : list[str]
             The column names.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row.get_column_names()
+        ['a', 'b']
         """
         return self._schema.get_column_names()
 
@@ -170,8 +265,15 @@ class Row:
 
         Raises
         ------
-        ColumnNameError
-            If the specified target column name does not exist.
+        UnknownColumnNameError
+            If the row does not contain the specified column.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row.get_type_of_column("a")
+        Integer
         """
         return self._schema.get_type_of_column(column_name)
 
@@ -187,6 +289,13 @@ class Row:
         -------
         count : int
             The number of columns.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row.count()
+        2
         """
         return self._data.shape[1]
 
@@ -202,6 +311,13 @@ class Row:
         -------
         data : dict[str, Any]
             Dictionary representation of the row.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.containers import Row
+        >>> row = Row.from_dict({"a": 1, "b": 2})
+        >>> row.to_dict()
+        {'a': 1, 'b': 2}
         """
         return {column_name: self.get_value(column_name) for column_name in self.get_column_names()}
 

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -27,6 +27,7 @@ from safeds.data.tabular.exceptions import (
     UnknownColumnNameError,
 )
 from safeds.data.tabular.typing import ColumnType, Schema
+
 from ._column import Column
 from ._row import Row
 

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -1,12 +1,12 @@
 from _pytest.python_api import raises
+
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.exceptions import SchemaMismatchError
-from safeds.data.tabular.typing import Integer, Schema, String
 
 
 def test_add_row_valid() -> None:
     table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    row = Row([5, 6], table1.schema)
+    row = Row.from_dict({"col1": 5, "col2": 6})
     table1 = table1.add_row(row)
     assert table1.count_rows() == 4
     assert table1.get_row(3) == row
@@ -15,9 +15,6 @@ def test_add_row_valid() -> None:
 
 def test_add_row_invalid() -> None:
     table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    row = Row(
-        [5, "Hallo"],
-        Schema({"col1": Integer(), "col2": String()}),
-    )
+    row = Row.from_dict({"col1": 5, "col2": "Hallo"})
     with raises(SchemaMismatchError):
         table1 = table1.add_row(row)

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -1,5 +1,4 @@
 from _pytest.python_api import raises
-
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.exceptions import SchemaMismatchError
 

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -1,17 +1,27 @@
-from safeds.data.tabular.containers import Row, Table
 import polars as pl
+from safeds.data.tabular.containers import Row, Table
 
 
 def test_add_rows_valid() -> None:
     table1 = Table.from_dict({"col1": ["a", "b", "c"], "col2": [1, 2, 4]})
-    row1 = Row(pl.DataFrame({
-        "col1": "d",
-        "col2": 6,
-    }), table1.schema)
-    row2 = Row(pl.DataFrame({
-        "col1": "e",
-        "col2": 8,
-    }), table1.schema)
+    row1 = Row(
+        pl.DataFrame(
+            {
+                "col1": "d",
+                "col2": 6,
+            },
+        ),
+        table1.schema,
+    )
+    row2 = Row(
+        pl.DataFrame(
+            {
+                "col1": "e",
+                "col2": 8,
+            },
+        ),
+        table1.schema,
+    )
     table1 = table1.add_rows([row1, row2])
     assert table1.count_rows() == 5
     assert table1.get_row(3) == row1
@@ -22,14 +32,24 @@ def test_add_rows_valid() -> None:
 
 def test_add_rows_table_valid() -> None:
     table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    row1 = Row(pl.DataFrame({
-        "col1": 5,
-        "col2": 6,
-    }), table1.schema)
-    row2 = Row(pl.DataFrame({
-        "col1": 7,
-        "col2": 8,
-    }), table1.schema)
+    row1 = Row(
+        pl.DataFrame(
+            {
+                "col1": 5,
+                "col2": 6,
+            },
+        ),
+        table1.schema,
+    )
+    row2 = Row(
+        pl.DataFrame(
+            {
+                "col1": 7,
+                "col2": 8,
+            },
+        ),
+        table1.schema,
+    )
     table2 = Table.from_rows([row1, row2])
     table1 = table1.add_rows(table2)
     assert table1.count_rows() == 5

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -1,10 +1,17 @@
 from safeds.data.tabular.containers import Row, Table
+import polars as pl
 
 
 def test_add_rows_valid() -> None:
     table1 = Table.from_dict({"col1": ["a", "b", "c"], "col2": [1, 2, 4]})
-    row1 = Row(["d", 6], table1.schema)
-    row2 = Row(["e", 8], table1.schema)
+    row1 = Row(pl.DataFrame({
+        "col1": "d",
+        "col2": 6,
+    }), table1.schema)
+    row2 = Row(pl.DataFrame({
+        "col1": "e",
+        "col2": 8,
+    }), table1.schema)
     table1 = table1.add_rows([row1, row2])
     assert table1.count_rows() == 5
     assert table1.get_row(3) == row1
@@ -15,8 +22,14 @@ def test_add_rows_valid() -> None:
 
 def test_add_rows_table_valid() -> None:
     table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    row1 = Row([5, 6], table1.schema)
-    row2 = Row([7, 8], table1.schema)
+    row1 = Row(pl.DataFrame({
+        "col1": 5,
+        "col2": 6,
+    }), table1.schema)
+    row2 = Row(pl.DataFrame({
+        "col1": 7,
+        "col2": 8,
+    }), table1.schema)
     table2 = Table.from_rows([row1, row2])
     table1 = table1.add_rows(table2)
     assert table1.count_rows() == 5

--- a/tests/safeds/data/tabular/containers/_table/test_to_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_rows.py
@@ -1,6 +1,7 @@
+import polars as pl
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.typing import Integer, Schema, String
-import polars as pl
+
 
 def test_to_rows() -> None:
     table = Table.from_dict(

--- a/tests/safeds/data/tabular/containers/_table/test_to_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_to_rows.py
@@ -1,6 +1,6 @@
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.typing import Integer, Schema, String
-
+import polars as pl
 
 def test_to_rows() -> None:
     table = Table.from_dict(
@@ -19,9 +19,9 @@ def test_to_rows() -> None:
         },
     )
     rows_expected = [
-        Row([1, 4, "d"], expected_schema),
-        Row([2, 5, "e"], expected_schema),
-        Row([3, 6, "f"], expected_schema),
+        Row(pl.DataFrame({"A": 1, "B": 4, "D": "d"}), expected_schema),
+        Row(pl.DataFrame({"A": 2, "B": 5, "D": "e"}), expected_schema),
+        Row(pl.DataFrame({"A": 3, "B": 6, "D": "f"}), expected_schema),
     ]
 
     rows_is = table.to_rows()

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -358,3 +358,19 @@ class TestToDict:
     )
     def test_should_return_dict_for_table(self, row: Row, expected: dict[str, Any]) -> None:
         assert row.to_dict() == expected
+
+
+class TestReprHtml:
+    @pytest.mark.parametrize(
+        "row",
+        [
+            Row(pl.DataFrame({})),
+            Row(pl.DataFrame({"a": 1, "b": 2})),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_table_element(self, row: Row) -> None:
+        assert "<table" in row._repr_html_()

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -26,7 +26,7 @@ class TestFromDict:
         ids=[
             "empty",
             "non-empty",
-        ]
+        ],
     )
     def test_should_create_row_from_dict(self, data: dict[str, Any], expected: Row) -> None:
         assert Row.from_dict(data) == expected
@@ -53,7 +53,7 @@ class TestInit:
             "empty",
             "one column",
             "two columns",
-        ]
+        ],
     )
     def test_should_use_the_schema_if_passed(self, row: Row, expected: Schema) -> None:
         assert row._schema == expected
@@ -67,7 +67,7 @@ class TestInit:
         ids=[
             "empty",
             "one column",
-        ]
+        ],
     )
     def test_should_infer_the_schema_if_not_passed(self, row: Row, expected: Schema) -> None:
         assert row._schema == expected

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -23,6 +23,10 @@ class TestFromDict:
                 Row(pl.DataFrame({"a": 1, "b": 2})),
             ),
         ],
+        ids=[
+            "empty",
+            "non-empty",
+        ]
     )
     def test_should_create_row_from_dict(self, data: dict[str, Any], expected: Row) -> None:
         assert Row.from_dict(data) == expected
@@ -45,6 +49,11 @@ class TestInit:
                 Schema({"col1": Integer(), "col2": String()}),
             ),
         ],
+        ids=[
+            "empty",
+            "one column",
+            "two columns",
+        ]
     )
     def test_should_use_the_schema_if_passed(self, row: Row, expected: Schema) -> None:
         assert row._schema == expected
@@ -55,6 +64,10 @@ class TestInit:
             (Row(pl.DataFrame()), Schema({})),
             (Row(pl.DataFrame({"col1": 0})), Schema({"col1": Integer()})),
         ],
+        ids=[
+            "empty",
+            "one column",
+        ]
     )
     def test_should_infer_the_schema_if_not_passed(self, row: Row, expected: Schema) -> None:
         assert row._schema == expected
@@ -82,6 +95,20 @@ class TestEq:
         assert (row1.__eq__(row2)) == expected
 
     @pytest.mark.parametrize(
+        "row",
+        [
+            Row.from_dict({}),
+            Row.from_dict({"col1": 0}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_return_true_if_objects_are_identical(self, row: Row) -> None:
+        assert (row.__eq__(row)) is True
+
+    @pytest.mark.parametrize(
         ("row", "other"),
         [
             (Row.from_dict({"col1": 0}), None),
@@ -103,6 +130,10 @@ class TestGetitem:
             (Row.from_dict({"col1": 0}), "col1", 0),
             (Row.from_dict({"col1": 0, "col2": "a"}), "col2", "a"),
         ],
+        ids=[
+            "one column",
+            "two columns",
+        ],
     )
     def test_should_return_the_value_in_the_column(self, row: Row, column_name: str, expected: Any) -> None:
         assert row[column_name] == expected
@@ -112,6 +143,10 @@ class TestGetitem:
         [
             (Row.from_dict({}), "col1"),
             (Row.from_dict({"col1": 0}), "col2"),
+        ],
+        ids=[
+            "empty row",
+            "column does not exist",
         ],
     )
     def test_should_raise_if_column_does_not_exist(self, row: Row, column_name: str) -> None:
@@ -127,6 +162,10 @@ class TestIter:
             (Row.from_dict({}), []),
             (Row.from_dict({"col1": 0}), ["col1"]),
         ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
     )
     def test_should_return_an_iterator_for_the_column_names(self, row: Row, expected: list[str]) -> None:
         assert list(row) == expected
@@ -138,6 +177,10 @@ class TestLen:
         [
             (Row.from_dict({}), 0),
             (Row.from_dict({"col1": 0, "col2": "a"}), 2),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
         ],
     )
     def test_should_return_the_number_of_columns(self, row: Row, expected: int) -> None:
@@ -187,6 +230,10 @@ class TestGetValue:
             (Row.from_dict({"col1": 0}), "col1", 0),
             (Row.from_dict({"col1": 0, "col2": "a"}), "col2", "a"),
         ],
+        ids=[
+            "one column",
+            "two columns",
+        ],
     )
     def test_should_return_the_value_in_the_column(self, row: Row, column_name: str, expected: Any) -> None:
         assert row.get_value(column_name) == expected
@@ -196,6 +243,10 @@ class TestGetValue:
         [
             (Row.from_dict({}), "col1"),
             (Row.from_dict({"col1": 0}), "col2"),
+        ],
+        ids=[
+            "empty row",
+            "column does not exist",
         ],
     )
     def test_should_raise_if_column_does_not_exist(self, row: Row, column_name: str) -> None:
@@ -211,6 +262,11 @@ class TestHasColumn:
             (Row.from_dict({"col1": 0}), "col1", True),
             (Row.from_dict({"col1": 0}), "col2", False),
         ],
+        ids=[
+            "empty row",
+            "column exists",
+            "column does not exist",
+        ],
     )
     def test_should_return_whether_the_row_has_the_column(self, row: Row, column_name: str, expected: bool) -> None:
         assert row.has_column(column_name) == expected
@@ -222,6 +278,10 @@ class TestGetColumnNames:
         [
             (Row.from_dict({}), []),
             (Row.from_dict({"col1": 0}), ["col1"]),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
         ],
     )
     def test_should_return_the_column_names(self, row: Row, expected: list[str]) -> None:
@@ -235,6 +295,10 @@ class TestGetTypeOfColumn:
             (Row.from_dict({"col1": 0}), "col1", Integer()),
             (Row.from_dict({"col1": 0, "col2": "a"}), "col2", String()),
         ],
+        ids=[
+            "one column",
+            "two columns",
+        ],
     )
     def test_should_return_the_type_of_the_column(self, row: Row, column_name: str, expected: ColumnType) -> None:
         assert row.get_type_of_column(column_name) == expected
@@ -244,6 +308,10 @@ class TestGetTypeOfColumn:
         [
             (Row.from_dict({}), "col1"),
             (Row.from_dict({"col1": 0}), "col2"),
+        ],
+        ids=[
+            "empty row",
+            "column does not exist",
         ],
     )
     def test_should_raise_if_column_does_not_exist(self, row: Row, column_name: str) -> None:
@@ -257,6 +325,10 @@ class TestCount:
         [
             (Row.from_dict({}), 0),
             (Row.from_dict({"col1": 0, "col2": "a"}), 2),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
         ],
     )
     def test_should_return_the_number_of_columns(self, row: Row, expected: int) -> None:
@@ -278,6 +350,10 @@ class TestToDict:
                     "b": 2,
                 },
             ),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
         ],
     )
     def test_should_return_dict_for_table(self, row: Row, expected: dict[str, Any]) -> None:

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -149,6 +149,42 @@ class TestLen:
         assert len(row) == expected
 
 
+class TestStr:
+    @pytest.mark.parametrize(
+        ("row", "expected"),
+        [
+            (Row.from_dict({}), "{}"),
+            (Row.from_dict({"col1": 0}), "{'col1': 0}"),
+            (Row.from_dict({"col1": 0, "col2": "a"}), "{\n    'col1': 0,\n    'col2': 'a'\n}"),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ]
+    )
+    def test_should_return_a_string_representation(self, row: Row, expected: str) -> None:
+        assert str(row) == expected
+
+
+class TestRepr:
+    @pytest.mark.parametrize(
+        ("row", "expected"),
+        [
+            (Row.from_dict({}), "Row({})"),
+            (Row.from_dict({"col1": 0}), "Row({'col1': 0})"),
+            (Row.from_dict({"col1": 0, "col2": "a"}), "Row({\n    'col1': 0,\n    'col2': 'a'\n})"),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ]
+    )
+    def test_should_return_a_string_representation(self, row: Row, expected: str) -> None:
+        assert repr(row) == expected
+
+
 class TestGetValue:
     @pytest.mark.parametrize(
         ("row", "column_name", "expected"),

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -1,10 +1,10 @@
 from typing import Any
 
+import polars as pl
 import pytest
 from safeds.data.tabular.containers import Row, Table
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 from safeds.data.tabular.typing import ColumnType, Integer, Schema, String
-import polars as pl
 
 
 class TestFromDict:
@@ -90,7 +90,7 @@ class TestEq:
         ids=[
             "Row vs. None",
             "Row vs. Table",
-        ]
+        ],
     )
     def test_should_return_not_implemented_if_other_is_not_row(self, row: Row, other: Any) -> None:
         assert (row.__eq__(other)) is NotImplemented
@@ -156,7 +156,7 @@ class TestStr:
             "empty",
             "single column",
             "multiple columns",
-        ]
+        ],
     )
     def test_should_return_a_string_representation(self, row: Row, expected: str) -> None:
         assert str(row) == expected
@@ -174,7 +174,7 @@ class TestRepr:
             "empty",
             "single column",
             "multiple columns",
-        ]
+        ],
     )
     def test_should_return_a_string_representation(self, row: Row, expected: str) -> None:
         assert repr(row) == expected


### PR DESCRIPTION
Closes partially #196.
Closes #149.

### Summary of Changes

* `Row` now uses a `polars.DataFrame` instead of a `pandas.Series` to store its data. The `DataFrame` can directly store the column names.
* Remove the `__hash__` method. A `Row` can no longer be used in a `set` and as the key of a `dict`. If we find a use-case for this, we'll add it back.
