### PR TITLE
feat: Set `column_names` in `fit` methods of table transformers to be required

### DIFF
--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -90,7 +90,7 @@ class Imputer(TableTransformer):
         self._column_names: list[str] | None = None
 
     # noinspection PyProtectedMember
-    def fit(self, table: Table, column_names: list[str] | None = None) -> Imputer:
+    def fit(self, table: Table, column_names: list[str] | None) -> Imputer:
         """
         Learn a transformation for a set of columns in a table.
 

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -27,7 +27,7 @@ class LabelEncoder(InvertibleTableTransformer):
         self._wrapped_transformer: sk_OrdinalEncoder | None = None
         self._column_names: list[str] | None = None
 
-    def fit(self, table: Table, column_names: list[str] | None = None) -> LabelEncoder:
+    def fit(self, table: Table, column_names: list[str] | None) -> LabelEncoder:
         """
         Learn a transformation for a set of columns in a table.
 

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -18,7 +18,7 @@ class OneHotEncoder(InvertibleTableTransformer):
         self._column_names: dict[str, list[str]] | None = None
 
     # noinspection PyProtectedMember
-    def fit(self, table: Table, column_names: list[str] | None = None) -> OneHotEncoder:
+    def fit(self, table: Table, column_names: list[str] | None) -> OneHotEncoder:
         """
         Learn a transformation for a set of columns in a table.
 

--- a/src/safeds/data/tabular/transformation/_table_transformer.py
+++ b/src/safeds/data/tabular/transformation/_table_transformer.py
@@ -11,7 +11,7 @@ class TableTransformer(ABC):
     """Learn a transformation for a set of columns in a `Table` and transform another `Table` with the same columns."""
 
     @abstractmethod
-    def fit(self, table: Table, column_names: list[str] | None = None) -> TableTransformer:
+    def fit(self, table: Table, column_names: list[str] | None) -> TableTransformer:
         """
         Learn a transformation for a set of columns in a table.
 

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -24,7 +24,7 @@ class TestFit:
         )
 
         transformer = Imputer(Imputer.Strategy.Constant(0))
-        transformer.fit(table)
+        transformer.fit(table, None)
 
         assert transformer._wrapped_transformer is None
         assert transformer._column_names is None
@@ -38,7 +38,7 @@ class TestTransform:
             },
         )
 
-        transformer = Imputer(Imputer.Strategy.Constant(0)).fit(table_to_fit)
+        transformer = Imputer(Imputer.Strategy.Constant(0)).fit(table_to_fit, None)
 
         table_to_transform = Table.from_dict(
             {
@@ -75,7 +75,7 @@ class TestIsFitted:
         )
 
         transformer = Imputer(Imputer.Strategy.Mean())
-        fitted_transformer = transformer.fit(table)
+        fitted_transformer = transformer.fit(table, None)
         assert fitted_transformer.is_fitted()
 
 

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -23,7 +23,7 @@ class TestFit:
         )
 
         transformer = LabelEncoder()
-        transformer.fit(table)
+        transformer.fit(table, None)
 
         assert transformer._wrapped_transformer is None
         assert transformer._column_names is None
@@ -37,7 +37,7 @@ class TestTransform:
             },
         )
 
-        transformer = LabelEncoder().fit(table_to_fit)
+        transformer = LabelEncoder().fit(table_to_fit, None)
 
         table_to_transform = Table.from_dict(
             {
@@ -74,7 +74,7 @@ class TestIsFitted:
         )
 
         transformer = LabelEncoder()
-        fitted_transformer = transformer.fit(table)
+        fitted_transformer = transformer.fit(table, None)
         assert fitted_transformer.is_fitted()
 
 
@@ -150,7 +150,7 @@ class TestInverseTransform:
         ],
     )
     def test_should_return_original_table(self, table: Table) -> None:
-        transformer = LabelEncoder().fit(table)
+        transformer = LabelEncoder().fit(table, None)
 
         assert transformer.inverse_transform(transformer.transform(table)) == table
 
@@ -161,7 +161,7 @@ class TestInverseTransform:
             },
         )
 
-        transformer = LabelEncoder().fit(table)
+        transformer = LabelEncoder().fit(table, None)
         transformed_table = transformer.transform(table)
         transformer.inverse_transform(transformed_table)
 

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -23,7 +23,7 @@ class TestFit:
         )
 
         transformer = OneHotEncoder()
-        transformer.fit(table)
+        transformer.fit(table, None)
 
         assert transformer._wrapped_transformer is None
         assert transformer._column_names is None
@@ -37,7 +37,7 @@ class TestTransform:
             },
         )
 
-        transformer = OneHotEncoder().fit(table_to_fit)
+        transformer = OneHotEncoder().fit(table_to_fit, None)
 
         table_to_transform = Table.from_dict(
             {
@@ -74,7 +74,7 @@ class TestIsFitted:
         )
 
         transformer = OneHotEncoder()
-        fitted_transformer = transformer.fit(table)
+        fitted_transformer = transformer.fit(table, None)
         assert fitted_transformer.is_fitted()
 
 
@@ -247,7 +247,7 @@ class TestInverseTransform:
             },
         )
 
-        transformer = OneHotEncoder().fit(table)
+        transformer = OneHotEncoder().fit(table, None)
         transformed_table = transformer.transform(table)
         transformer.inverse_transform(transformed_table)
 


### PR DESCRIPTION
Closes #179.

### Summary of Changes

Every `fit` method of `TableTransformer`s now requires `column_names` to be explicitly set.