### PR TITLE
fix: selectively ignore one warning instead of all warnings

### DIFF
--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import warnings
-from typing import Any
-
 from sklearn.preprocessing import OrdinalEncoder as sk_OrdinalEncoder
 
 from safeds.data.tabular.containers import Table
@@ -10,13 +7,6 @@ from safeds.data.tabular.exceptions import TransformerNotFittedError, UnknownCol
 from safeds.data.tabular.transformation._table_transformer import (
     InvertibleTableTransformer,
 )
-
-
-def warn(*_: Any, **__: Any) -> None:
-    pass
-
-
-warnings.warn = warn
 
 
 # noinspection PyProtectedMember

--- a/src/safeds/ml/classical/_util_sklearn.py
+++ b/src/safeds/ml/classical/_util_sklearn.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 from safeds.data.tabular.containers import Table, TaggedTable
@@ -84,7 +85,9 @@ def predict(model: Any, dataset: Table, feature_names: list[str] | None, target_
     result_set.columns = dataset.column_names
 
     try:
-        predicted_target_vector = model.predict(dataset_df.values)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="X does not have valid feature names")
+            predicted_target_vector = model.predict(dataset_df.values)
         result_set[target_name] = predicted_target_vector
         return Table(result_set).tag_columns(target_name=target_name, feature_names=feature_names)
     except ValueError as exception:


### PR DESCRIPTION
### Summary of Changes

When we tried to test whether a specific warning was issued, we discovered that these tests failed if all tests were run but passed if only the test for the warning was run. This happened because one module basically disabled all warnings when it was loaded. This behavior is now removed and instead one specific warning is disabled for the one call that may create it.
