### PR TITLE
refactor: replace `_ipython_display_` methods with `_repr_html_`

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -8,7 +8,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from IPython.core.display_functions import DisplayHandle, display
 
 from safeds.data.image.containers import Image
 from safeds.data.image.typing import ImageFormat
@@ -535,20 +534,16 @@ class Column:
     # IPython integration
     # ------------------------------------------------------------------------------------------------------------------
 
-    def _ipython_display_(self) -> DisplayHandle:
+    def _repr_html_(self) -> str:
         """
-        Return a display object for the column to be used in Jupyter Notebooks.
+        Return an HTML representation of the column.
 
         Returns
         -------
-        output : DisplayHandle
-            Output object.
+        output : str
+            The generated HTML.
         """
-        tmp = self._data.to_frame()
-        tmp.columns = [self.name]
-
-        with pd.option_context("display.max_rows", tmp.shape[0], "display.max_columns", tmp.shape[1]):
-            return display(tmp)
+        return self._data.to_frame().to_html(max_rows=self._data.size, max_cols=1, notebook=True)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Other

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -543,7 +543,10 @@ class Column:
         output : str
             The generated HTML.
         """
-        return self._data.to_frame().to_html(max_rows=self._data.size, max_cols=1, notebook=True)
+        frame = self._data.to_frame()
+        frame.columns = [self.name]
+
+        return frame.to_html(max_rows=self._data.size, max_cols=1, notebook=True)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Other

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from IPython.core.display_functions import DisplayHandle, display
 from pandas import DataFrame
 from scipy import stats
 
@@ -26,7 +25,6 @@ from safeds.data.tabular.exceptions import (
     UnknownColumnNameError,
 )
 from safeds.data.tabular.typing import ColumnType, Schema
-
 from ._column import Column
 from ._row import Row
 
@@ -1269,20 +1267,16 @@ class Table:
     # IPython integration
     # ------------------------------------------------------------------------------------------------------------------
 
-    def _ipython_display_(self) -> DisplayHandle:
+    def _repr_html_(self) -> str:
         """
-        Return a display object for the column to be used in Jupyter Notebooks.
+        Return an HTML representation of the table.
 
         Returns
         -------
-        output : DisplayHandle
-            Output object.
+        output : str
+            The generated HTML.
         """
-        tmp = self._data.copy(deep=True)
-        tmp.columns = self.column_names
-
-        with pd.option_context("display.max_rows", tmp.shape[0], "display.max_columns", tmp.shape[1]):
-            return display(tmp)
+        return self._data.to_html(max_rows=self._data.shape[0], max_cols=self._data.shape[1], notebook=True)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Dataframe interchange protocol

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -25,6 +25,7 @@ from safeds.data.tabular.exceptions import (
     UnknownColumnNameError,
 )
 from safeds.data.tabular.typing import ColumnType, Schema
+
 from ._column import Column
 from ._row import Row
 

--- a/tests/safeds/data/tabular/containers/test_column.py
+++ b/tests/safeds/data/tabular/containers/test_column.py
@@ -2,6 +2,8 @@ import pytest
 
 from safeds.data.tabular.containers import Column
 
+import regex as re
+
 
 class TestReprHtml:
     @pytest.mark.parametrize(
@@ -16,4 +18,34 @@ class TestReprHtml:
         ],
     )
     def test_should_contain_table_element(self, column: Column) -> None:
-        assert "<table" in column._repr_html_()
+        pattern = r"<table.*?>.*?</table>"
+        assert re.search(pattern, column._repr_html_(), flags=re.S) is not None
+
+    @pytest.mark.parametrize(
+        "column",
+        [
+            Column("a", []),
+            Column("a", [1, 2, 3]),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_th_element_for_column_name(self, column: Column) -> None:
+        assert f"<th>{column.name}</th>" in column._repr_html_()
+
+    @pytest.mark.parametrize(
+        "column",
+        [
+            Column("a", []),
+            Column("a", [1, 2, 3]),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_td_element_for_each_value(self, column: Column) -> None:
+        for value in column:
+            assert f"<td>{value}</td>" in column._repr_html_()

--- a/tests/safeds/data/tabular/containers/test_column.py
+++ b/tests/safeds/data/tabular/containers/test_column.py
@@ -1,0 +1,19 @@
+import pytest
+
+from safeds.data.tabular.containers import Column
+
+
+class TestReprHtml:
+    @pytest.mark.parametrize(
+        "column",
+        [
+            Column("a", []),
+            Column("a", [1, 2, 3]),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_table_element(self, column: Column) -> None:
+        assert "<table" in column._repr_html_()

--- a/tests/safeds/data/tabular/containers/test_column.py
+++ b/tests/safeds/data/tabular/containers/test_column.py
@@ -1,8 +1,6 @@
 import pytest
-
-from safeds.data.tabular.containers import Column
-
 import regex as re
+from safeds.data.tabular.containers import Column
 
 
 class TestReprHtml:

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 import pandas as pd
@@ -414,4 +415,35 @@ class TestReprHtml:
         ],
     )
     def test_should_contain_table_element(self, row: Row) -> None:
-        assert "<table" in row._repr_html_()
+        pattern = r"<table.*?>.*?</table>"
+        assert re.search(pattern, row._repr_html_(), flags=re.S) is not None
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            Row(),
+            Row({"a": 1, "b": 2}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_th_element_for_each_column_name(self, row: Row) -> None:
+        for column_name in row.column_names:
+            assert f"<th>{column_name}</th>" in row._repr_html_()
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            Row(),
+            Row({"a": 1, "b": 2}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_td_element_for_each_value(self, row: Row) -> None:
+        for value in row.values():
+            assert f"<td>{value}</td>" in row._repr_html_()

--- a/tests/safeds/data/tabular/containers/test_table.py
+++ b/tests/safeds/data/tabular/containers/test_table.py
@@ -53,6 +53,22 @@ class TestToDict:
         assert table.to_dict() == expected
 
 
+class TestReprHtml:
+    @pytest.mark.parametrize(
+        "table",
+        [
+            Table.from_dict({}),
+            Table.from_dict({"a": [1, 2], "b": [3, 4]}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_table_element(self, table: Table) -> None:
+        assert "<table" in table._repr_html_()
+
+
 class TestDataframe:
     @pytest.mark.parametrize(
         "table",

--- a/tests/safeds/data/tabular/containers/test_table.py
+++ b/tests/safeds/data/tabular/containers/test_table.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 import pytest
@@ -66,7 +67,39 @@ class TestReprHtml:
         ],
     )
     def test_should_contain_table_element(self, table: Table) -> None:
-        assert "<table" in table._repr_html_()
+        pattern = r"<table.*?>.*?</table>"
+        assert re.search(pattern, table._repr_html_(), flags=re.S) is not None
+
+    @pytest.mark.parametrize(
+        "table",
+        [
+            Table.from_dict({}),
+            Table.from_dict({"a": [1, 2], "b": [3, 4]}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_th_element_for_each_column_name(self, table: Table) -> None:
+        for column_name in table.column_names:
+            assert f"<th>{column_name}</th>" in table._repr_html_()
+
+    @pytest.mark.parametrize(
+        "table",
+        [
+            Table.from_dict({}),
+            Table.from_dict({"a": [1, 2], "b": [3, 4]}),
+        ],
+        ids=[
+            "empty",
+            "non-empty",
+        ],
+    )
+    def test_should_contain_td_element_for_each_value(self, table: Table) -> None:
+        for column in table.to_columns():
+            for value in column:
+                assert f"<td>{value}</td>" in table._repr_html_()
 
 
 class TestDataframe:


### PR DESCRIPTION
### Summary of Changes

Use `_repr_html_` instead of `_ipython_display_` to display `Table`s and `Column`s in Jupyter notebooks.