### PR TITLE
feat: convert `Schema` to `dict` and format it nicely in a notebook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 filterwarnings = [
+    "ignore:Deprecated call to `pkg_resources.declare_namespace",
     "ignore:Jupyter is migrating its paths to use standard platformdirs"
 ]
 

--- a/src/safeds/data/tabular/typing/_schema.py
+++ b/src/safeds/data/tabular/typing/_schema.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from IPython.lib.pretty import PrettyPrinter
-
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 from safeds.data.tabular.typing._column_type import ColumnType
 
@@ -199,6 +197,28 @@ class Schema:
         if not self.has_column(column_name):
             raise UnknownColumnNameError([column_name])
         return self._schema[column_name]
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Conversion
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, ColumnType]:
+        """
+        Return a dictionary that maps column names to column types.
+
+        Returns
+        -------
+        data : dict[str, ColumnType]
+            Dictionary representation of the schema.
+
+        Examples
+        --------
+        >>> from safeds.data.tabular.typing import Integer, Schema, String
+        >>> schema = Schema({"A": Integer(), "B": String()})
+        >>> schema.to_dict()
+        {'A': Integer, 'B': String}
+        """
+        return dict(self._schema)  # defensive copy
 
     # ------------------------------------------------------------------------------------------------------------------
     # IPython Integration

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import pytest
+
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 from safeds.data.tabular.typing import Boolean, ColumnType, Integer, RealNumber, Schema, String
 
@@ -48,6 +49,24 @@ class TestFromPandasDataFrame:
         assert Schema._from_pandas_dataframe(dataframe) == expected
 
 
+class TestRepr:
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            (Schema({}), "Schema({})"),
+            (Schema({"A": Integer()}), "Schema({'A': Integer})"),
+            (Schema({"A": Integer(), "B": String()}), "Schema({\n    'A': Integer,\n    'B': String\n})"),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ],
+    )
+    def test_should_create_a_string_representation(self, schema: Schema, expected: str) -> None:
+        assert repr(schema) == expected
+
+
 class TestStr:
     @pytest.mark.parametrize(
         ("schema", "expected"),
@@ -62,7 +81,7 @@ class TestStr:
             "multiple columns",
         ],
     )
-    def test_should_create_a_printable_representation(self, schema: Schema, expected: str) -> None:
+    def test_should_create_a_string_representation(self, schema: Schema, expected: str) -> None:
         assert str(schema) == expected
 
 
@@ -213,3 +232,32 @@ class TestGetColumnIndex:
         schema = Schema({"A": Integer()})
         with pytest.raises(UnknownColumnNameError):
             schema._get_column_index("B")
+
+
+class TestReprMarkdown:
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            (Schema({}), "Empty Schema"),
+            (
+                Schema({"A": Integer()}),
+                "| Column Name | Column Type |\n"
+                "| --- | --- |\n"
+                "| A | Integer |"
+            ),
+            (
+                Schema({"A": Integer(), "B": String()}),
+                "| Column Name | Column Type |\n"
+                "| --- | --- |\n"
+                "| A | Integer |\n"
+                "| B | String |"
+            ),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ],
+    )
+    def test_should_create_a_string_representation(self, schema: Schema, expected: str) -> None:
+        assert schema._repr_markdown_() == expected

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -259,16 +259,11 @@ class TestReprMarkdown:
             (Schema({}), "Empty Schema"),
             (
                 Schema({"A": Integer()}),
-                "| Column Name | Column Type |\n"
-                "| --- | --- |\n"
-                "| A | Integer |"
+                "| Column Name | Column Type |\n| --- | --- |\n| A | Integer |"
             ),
             (
                 Schema({"A": Integer(), "B": String()}),
-                "| Column Name | Column Type |\n"
-                "| --- | --- |\n"
-                "| A | Integer |\n"
-                "| B | String |"
+                "| Column Name | Column Type |\n| --- | --- |\n| A | Integer |\n| B | String |"
             ),
         ],
         ids=[

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import pytest
-
 from safeds.data.tabular.exceptions import UnknownColumnNameError
 from safeds.data.tabular.typing import Boolean, ColumnType, Integer, RealNumber, Schema, String
 
@@ -257,13 +256,10 @@ class TestReprMarkdown:
         ("schema", "expected"),
         [
             (Schema({}), "Empty Schema"),
-            (
-                Schema({"A": Integer()}),
-                "| Column Name | Column Type |\n| --- | --- |\n| A | Integer |"
-            ),
+            (Schema({"A": Integer()}), "| Column Name | Column Type |\n| --- | --- |\n| A | Integer |"),
             (
                 Schema({"A": Integer(), "B": String()}),
-                "| Column Name | Column Type |\n| --- | --- |\n| A | Integer |\n| B | String |"
+                "| Column Name | Column Type |\n| --- | --- |\n| A | Integer |\n| B | String |",
             ),
         ],
         ids=[

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -234,6 +234,24 @@ class TestGetColumnIndex:
             schema._get_column_index("B")
 
 
+class TestToDict:
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            (Schema({}), {}),
+            (Schema({"A": Integer()}), {"A": Integer()}),
+            (Schema({"A": Integer(), "B": String()}), {"A": Integer(), "B": String()}),
+        ],
+        ids=[
+            "empty",
+            "single column",
+            "multiple columns",
+        ],
+    )
+    def test_should_return_dict_for_schema(self, schema: Schema, expected: str) -> None:
+        assert schema.to_dict() == expected
+
+
 class TestReprMarkdown:
     @pytest.mark.parametrize(
         ("schema", "expected"),


### PR DESCRIPTION
Closes #151.

### Summary of Changes

* Add method `to_dict` to `Schema` to convert a `Schema` to a `dict`
* Nicely format `Schema` in Jupyter notebook
* Add examples to docstrings
