### PR TITLE
feat: replace prefix `n` with `number_of`

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -167,13 +167,13 @@ class Column(Sequence[_T]):
         return self._name
 
     @property
-    def n_rows(self) -> int:
+    def number_of_rows(self) -> int:
         """
         Return the number of elements in the column.
 
         Returns
         -------
-        n_rows : int
+        number_of_rows : int
             The number of elements.
         """
         return len(self._data)

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -334,13 +334,11 @@ class Column(Sequence[_T]):
         """
         if not self._type.is_numeric() or not other_column._type.is_numeric():
             raise NonNumericColumnError(
-                f"Columns must be numerical. {self.name} is {self._type}, "
-                f"{other_column.name} is {other_column._type}.",
+                f"Columns must be numerical. {self.name} is {self._type}, {other_column.name} is {other_column._type}.",
             )
         if self._data.size != other_column._data.size:
             raise ColumnLengthMismatchError(
-                f"{self.name} is of size {self._data.size}, "
-                f"{other_column.name} is of size {other_column._data.size}.",
+                f"{self.name} is of size {self._data.size}, {other_column.name} is of size {other_column._data.size}.",
             )
         return self._data.corr(other_column._data)
 

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -227,7 +227,7 @@ class Row(Mapping[str, Any]):
 
         Returns
         -------
-        n_columns : int
+        number_of_columns : int
             The number of columns.
 
         Examples
@@ -307,20 +307,20 @@ class Row(Mapping[str, Any]):
         return self._schema.column_names
 
     @property
-    def n_columns(self) -> int:
+    def number_of_column(self) -> int:
         """
         Return the number of columns in this row.
 
         Returns
         -------
-        n_columns : int
+        number_of_column : int
             The number of columns.
 
         Examples
         --------
         >>> from safeds.data.tabular.containers import Row
         >>> row = Row({"a": 1, "b": 2})
-        >>> row.n_columns
+        >>> row.number_of_column
         2
         """
         return self._data.shape[1]

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -280,25 +280,25 @@ class Table:
         return self._schema.column_names
 
     @property
-    def n_columns(self) -> int:
+    def number_of_columns(self) -> int:
         """
         Return the number of columns.
 
         Returns
         -------
-        n_columns : int
+        number_of_columns : int
             The number of columns.
         """
         return self._data.shape[1]
 
     @property
-    def n_rows(self) -> int:
+    def number_of_rows(self) -> int:
         """
         Return the number of rows.
 
         Returns
         -------
-        n_rows : int
+        number_of_rows : int
             The number of rows.
         """
         return self._data.shape[0]
@@ -481,8 +481,8 @@ class Table:
         if self.has_column(column.name):
             raise DuplicateColumnNameError(column.name)
 
-        if column._data.size != self.n_rows:
-            raise ColumnSizeError(str(self.n_rows), str(column._data.size))
+        if column._data.size != self.number_of_rows:
+            raise ColumnSizeError(str(self.number_of_rows), str(column._data.size))
 
         result = self._data.copy()
         result.columns = self._schema.column_names
@@ -518,8 +518,8 @@ class Table:
             if column.name in result.columns:
                 raise DuplicateColumnNameError(column.name)
 
-            if column._data.size != self.n_rows:
-                raise ColumnSizeError(str(self.n_rows), str(column._data.size))
+            if column._data.size != self.number_of_rows:
+                raise ColumnSizeError(str(self.number_of_rows), str(column._data.size))
 
             result[column.name] = column._data
         return Table(result)
@@ -792,8 +792,8 @@ class Table:
         if new_column.name in self._schema.column_names and new_column.name != old_column_name:
             raise DuplicateColumnNameError(new_column.name)
 
-        if self.n_rows != new_column._data.size:
-            raise ColumnSizeError(str(self.n_rows), str(new_column._data.size))
+        if self.number_of_rows != new_column._data.size:
+            raise ColumnSizeError(str(self.number_of_rows), str(new_column._data.size))
 
         if old_column_name != new_column.name:
             renamed_table = self.rename_column(old_column_name, new_column.name)
@@ -852,9 +852,9 @@ class Table:
             start = 0
 
         if end is None:
-            end = self.n_rows
+            end = self.number_of_rows
 
-        if start < 0 or end < 0 or start >= self.n_rows or end > self.n_rows or end < start:
+        if start < 0 or end < 0 or start >= self.number_of_rows or end > self.number_of_rows or end < start:
             raise ValueError("The given index is out of bounds")
 
         new_df = self._data.iloc[start:end:step]
@@ -937,8 +937,8 @@ class Table:
         if percentage_in_first <= 0 or percentage_in_first >= 1:
             raise ValueError("the given percentage is not in range")
         return (
-            self.slice_rows(0, round(percentage_in_first * self.n_rows)),
-            self.slice_rows(round(percentage_in_first * self.n_rows)),
+            self.slice_rows(0, round(percentage_in_first * self.number_of_rows)),
+            self.slice_rows(round(percentage_in_first * self.number_of_rows)),
         )
 
     def tag_columns(self, target_name: str, feature_names: list[str] | None = None) -> TaggedTable:

--- a/tests/safeds/data/tabular/containers/_column/test_number_of_rows.py
+++ b/tests/safeds/data/tabular/containers/_column/test_number_of_rows.py
@@ -16,4 +16,4 @@ from safeds.data.tabular.containers import Column
     ],
 )
 def test_should_return_the_number_of_rows(column: Column, expected: int) -> None:
-    assert column.n_rows == expected
+    assert column.number_of_rows == expected

--- a/tests/safeds/data/tabular/containers/_table/test_add_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_column.py
@@ -14,7 +14,7 @@ from safeds.data.tabular.typing import ColumnType, Integer, String
 def test_add_column_valid(column: Column, col_type: ColumnType) -> None:
     table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
     table1 = table1.add_column(column)
-    assert table1.n_columns == 3
+    assert table1.number_of_columns == 3
     assert table1.get_column("col3") == column
     assert isinstance(table1.schema.get_column_type("col1"), Integer)
     assert isinstance(table1.schema.get_column_type("col2"), Integer)

--- a/tests/safeds/data/tabular/containers/_table/test_add_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_columns.py
@@ -7,7 +7,7 @@ def test_add_columns_valid() -> None:
     col3 = Column("col3", [0, -1, -2])
     col4 = Column("col4", ["a", "b", "c"])
     table1 = table1.add_columns([col3, col4])
-    assert table1.n_columns == 4
+    assert table1.number_of_columns == 4
     assert table1.get_column("col3") == col3
     assert table1.get_column("col4") == col4
     assert isinstance(table1.schema.get_column_type("col1"), Integer)
@@ -22,7 +22,7 @@ def test_add_columns_table_valid() -> None:
     col4 = Column("col4", ["a", "b", "c"])
     table2 = Table.from_columns([col3, col4])
     table1 = table1.add_columns(table2)
-    assert table1.n_columns == 4
+    assert table1.number_of_columns == 4
     assert table1.get_column("col3") == col3
     assert table1.get_column("col4") == col4
     assert isinstance(table1.schema.get_column_type("col1"), Integer)

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -7,7 +7,7 @@ def test_add_row_valid() -> None:
     table1 = Table.from_dict({"col1": [1, 2, 1], "col2": [1, 2, 4]})
     row = Row({"col1": 5, "col2": 6})
     table1 = table1.add_row(row)
-    assert table1.n_rows == 4
+    assert table1.number_of_rows == 4
     assert table1.get_row(3) == row
     assert table1.schema == row._schema
 

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -23,7 +23,7 @@ def test_add_rows_valid() -> None:
         table1.schema,
     )
     table1 = table1.add_rows([row1, row2])
-    assert table1.n_rows == 5
+    assert table1.number_of_rows == 5
     assert table1.get_row(3) == row1
     assert table1.get_row(4) == row2
     assert table1.schema == row1._schema
@@ -52,7 +52,7 @@ def test_add_rows_table_valid() -> None:
     )
     table2 = Table.from_rows([row1, row2])
     table1 = table1.add_rows(table2)
-    assert table1.n_rows == 5
+    assert table1.number_of_rows == 5
     assert table1.get_row(3) == row1
     assert table1.get_row(4) == row2
     assert table1.schema == row1._schema

--- a/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_filter_rows.py
@@ -7,8 +7,8 @@ def test_filter_rows_valid() -> None:
     result_table = table.filter_rows(lambda row: row.get_value("col1") == 1)
     assert result_table.get_column("col1").get_value(0) == 1
     assert result_table.get_column("col2").get_value(1) == 4
-    assert result_table.n_columns == 2
-    assert result_table.n_rows == 2
+    assert result_table.number_of_columns == 2
+    assert result_table.number_of_rows == 2
 
 
 # noinspection PyTypeChecker

--- a/tests/safeds/data/tabular/containers/_table/test_number_of_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_number_of_columns.py
@@ -10,5 +10,5 @@ from safeds.data.tabular.containers import Table
         (Table.from_dict({"col1": [], "col2": []}), 2),
     ],
 )
-def test_count_columns(table: Table, expected: int) -> None:
-    assert table.n_columns == expected
+def test_number_of_columns(table: Table, expected: int) -> None:
+    assert table.number_of_columns == expected

--- a/tests/safeds/data/tabular/containers/_table/test_number_of_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_number_of_rows.py
@@ -10,5 +10,5 @@ from safeds.data.tabular.containers import Table
         (Table.from_dict({"col1": [1, 2], "col2": [3, 4]}), 2),
     ],
 )
-def test_count_rows(table: Table, expected: int) -> None:
-    assert table.n_rows == expected
+def test_number_of_rows(table: Table, expected: int) -> None:
+    assert table.number_of_rows == expected

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_missing_values.py
@@ -12,7 +12,7 @@ def test_remove_rows_with_missing_values_valid() -> None:
         },
     )
     updated_table = table.remove_rows_with_missing_values()
-    assert updated_table.n_rows == 2
+    assert updated_table.number_of_rows == 2
 
 
 def test_remove_rows_with_missing_values_empty() -> None:

--- a/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
+++ b/tests/safeds/data/tabular/containers/_table/test_remove_rows_with_outliers.py
@@ -12,8 +12,8 @@ def test_remove_rows_with_outliers_no_outliers() -> None:
     )
     names = table.column_names
     result = table.remove_rows_with_outliers()
-    assert result.n_rows == 3
-    assert result.n_columns == 3
+    assert result.number_of_rows == 3
+    assert result.number_of_columns == 3
     assert names == table.column_names
 
 
@@ -54,5 +54,5 @@ def test_remove_rows_with_outliers_with_outliers() -> None:
 def test_remove_rows_with_outliers_no_rows() -> None:
     table = Table([], Schema({"col1": RealNumber()}))
     result = table.remove_rows_with_outliers()
-    assert result.n_rows == 0
-    assert result.n_columns == 1
+    assert result.number_of_rows == 0
+    assert result.number_of_columns == 1

--- a/tests/safeds/data/tabular/containers/_table/test_rename.py
+++ b/tests/safeds/data/tabular/containers/_table/test_rename.py
@@ -12,7 +12,7 @@ def test_rename_valid(name_from: str, name_to: str, column_one: str, column_two:
     renamed_table = table.rename_column(name_from, name_to)
     assert renamed_table.schema.has_column(column_one)
     assert renamed_table.schema.has_column(column_two)
-    assert renamed_table.n_columns == 2
+    assert renamed_table.number_of_columns == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/containers/_table/test_sort_columns.py
+++ b/tests/safeds/data/tabular/containers/_table/test_sort_columns.py
@@ -41,5 +41,5 @@ def test_sort_columns_valid(query: Callable[[Column, Column], int], col1: int, c
     assert table_sorted_columns[1] == columns[col2]
     assert table_sorted_columns[2] == columns[col3]
     assert table_sorted_columns[3] == columns[col4]
-    assert table_sorted.n_columns == 4
-    assert table_sorted.n_rows == table1.n_rows
+    assert table_sorted.number_of_columns == 4
+    assert table_sorted.number_of_rows == table1.number_of_rows

--- a/tests/safeds/data/tabular/containers/_table/test_table.py
+++ b/tests/safeds/data/tabular/containers/_table/test_table.py
@@ -5,7 +5,7 @@ from safeds.data.tabular.typing import RealNumber, Schema
 def test_create_empty_table() -> None:
     table = Table([], Schema({"col1": RealNumber()}))
     col = table.get_column("col1")
-    assert col.n_rows == 0
+    assert col.number_of_rows == 0
     assert isinstance(col.type, RealNumber)
     assert col.name == "col1"
 

--- a/tests/safeds/data/tabular/containers/test_row.py
+++ b/tests/safeds/data/tabular/containers/test_row.py
@@ -281,7 +281,7 @@ class TestColumnNames:
         assert row.column_names == expected
 
 
-class TestNColumns:
+class TestNumberOfColumns:
     @pytest.mark.parametrize(
         ("row", "expected"),
         [
@@ -294,7 +294,7 @@ class TestNColumns:
         ],
     )
     def test_should_return_the_number_of_columns(self, row: Row, expected: int) -> None:
-        assert row.n_columns == expected
+        assert row.number_of_column == expected
 
 
 class TestGetValue:


### PR DESCRIPTION
### Summary of Changes

* Rename `n_columns` to `number_of_columns`
* Rename `n_rows` to `number_of_rows`

Reason: The prefix `n` is commonly used instead of `number_of`. However, we also need to add a parameter to `AdaBoost` to set the maximum number of learners (#171). Calling that `maximum_n_learners` doesn't look nearly as readable to me as `maximum_number_of_learners`. And if we don't use `n` to replace `number_of` here, we shouldn't use this anywhere.
