### PR TITLE
refactor: create `Table` from `pandas.DataFrame`

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -23,10 +23,10 @@ from safeds.data.tabular.typing import ColumnType
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
-_T = TypeVar("_T")
+T = TypeVar("T")
 
 
-class Column(Sequence[_T]):
+class Column(Sequence[T]):
     """
     A column is a named collection of values.
 
@@ -34,7 +34,7 @@ class Column(Sequence[_T]):
     ----------
     name : str
         The name of the column.
-    data : Sequence[_T]
+    data : Sequence[T]
         The data.
 
     Examples
@@ -82,7 +82,7 @@ class Column(Sequence[_T]):
     # Dunder methods
     # ------------------------------------------------------------------------------------------------------------------
 
-    def __init__(self, name: str, data: Sequence[_T] | None = None) -> None:
+    def __init__(self, name: str, data: Sequence[T] | None = None) -> None:
         """
         Create a column.
 
@@ -90,7 +90,7 @@ class Column(Sequence[_T]):
         ----------
         name : str
             The name of the column.
-        data : Sequence[_T] | None
+        data : Sequence[T] | None
             The data. If None, an empty column is created.
 
         Examples
@@ -117,14 +117,14 @@ class Column(Sequence[_T]):
         return self.name == other.name and self._data.equals(other._data)
 
     @overload
-    def __getitem__(self, index: int) -> _T:
+    def __getitem__(self, index: int) -> T:
         ...
 
     @overload
-    def __getitem__(self, index: slice) -> Column[_T]:
+    def __getitem__(self, index: slice) -> Column[T]:
         ...
 
-    def __getitem__(self, index: int | slice) -> _T | Column[_T]:
+    def __getitem__(self, index: int | slice) -> T | Column[T]:
         if isinstance(index, int):
             if index < 0 or index >= self._data.size:
                 raise IndexOutOfBoundsError(index)
@@ -138,7 +138,7 @@ class Column(Sequence[_T]):
             data = self._data[index].reset_index(drop=True).rename(self.name)
             return Column._from_pandas_series(data, self._type)
 
-    def __iter__(self) -> Iterator[_T]:
+    def __iter__(self) -> Iterator[T]:
         return iter(self._data)
 
     def __len__(self) -> int:
@@ -194,18 +194,18 @@ class Column(Sequence[_T]):
     # Getters
     # ------------------------------------------------------------------------------------------------------------------
 
-    def get_unique_values(self) -> list[_T]:
+    def get_unique_values(self) -> list[T]:
         """
         Return a list of all unique values in the column.
 
         Returns
         -------
-        unique_values : list[_T]
+        unique_values : list[T]
             List of unique values in the column.
         """
         return list(self._data.unique())
 
-    def get_value(self, index: int) -> _T:
+    def get_value(self, index: int) -> T:
         """
         Return column value at specified index, starting at 0.
 
@@ -233,13 +233,13 @@ class Column(Sequence[_T]):
     # Information
     # ------------------------------------------------------------------------------------------------------------------
 
-    def all(self, predicate: Callable[[_T], bool]) -> bool:
+    def all(self, predicate: Callable[[T], bool]) -> bool:
         """
         Check if all values have a given property.
 
         Parameters
         ----------
-        predicate : Callable[[_T], bool])
+        predicate : Callable[[T], bool])
             Callable that is used to find matches.
 
         Returns
@@ -249,13 +249,13 @@ class Column(Sequence[_T]):
         """
         return all(predicate(value) for value in self._data)
 
-    def any(self, predicate: Callable[[_T], bool]) -> bool:
+    def any(self, predicate: Callable[[T], bool]) -> bool:
         """
         Check if any value has a given property.
 
         Parameters
         ----------
-        predicate : Callable[[_T], bool])
+        predicate : Callable[[T], bool])
             Callable that is used to find matches.
 
         Returns
@@ -265,13 +265,13 @@ class Column(Sequence[_T]):
         """
         return any(predicate(value) for value in self._data)
 
-    def none(self, predicate: Callable[[_T], bool]) -> bool:
+    def none(self, predicate: Callable[[T], bool]) -> bool:
         """
         Check if no values has a given property.
 
         Parameters
         ----------
-        predicate : Callable[[_T], bool])
+        predicate : Callable[[T], bool])
             Callable that is used to find matches.
 
         Returns
@@ -456,13 +456,13 @@ class Column(Sequence[_T]):
             raise ColumnSizeError("> 0", "0")
         return self._count_missing_values() / self._data.size
 
-    def mode(self) -> list[_T]:
+    def mode(self) -> list[T]:
         """
         Return the mode of the column.
 
         Returns
         -------
-        mode: list[_T]
+        mode: list[T]
             Returns a list with the most common values.
         """
         return self._data.mode().tolist()

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -70,12 +70,20 @@ class Row(Mapping[str, Any]):
         row : Row
             The created row.
 
+        Raises
+        ------
+        ValueError
+            If the dataframe does not contain exactly one row.
+
         Examples
         --------
         >>> import pandas as pd
         >>> from safeds.data.tabular.containers import Row
         >>> row = Row._from_pandas_dataframe(pd.DataFrame({"a": [1], "b": [2]}))
         """
+        if data.shape[0] != 1:
+            raise ValueError("The dataframe has to contain exactly one row.")
+
         data = data.reset_index(drop=True)
 
         result = object.__new__(Row)

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -215,6 +215,42 @@ class Table:
         dataframe.columns = schema_compare.column_names
         return Table(dataframe)
 
+    @staticmethod
+    def _from_pandas_dataframe(data: pd.DataFrame, schema: Schema | None = None) -> Table:
+        """
+        Create a table from a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            The data.
+        schema : Schema | None
+            The schema. If None, the schema is inferred from the data.
+
+        Returns
+        -------
+        table : Table
+            The created table.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from safeds.data.tabular.containers import Table
+        >>> table = Table._from_pandas_dataframe(pd.DataFrame({"a": [1], "b": [2]}))
+        """
+        data = data.reset_index(drop=True)
+
+        result = object.__new__(Table)
+        result._data = data
+
+        if schema is None:
+            # noinspection PyProtectedMember
+            result._schema = Schema._from_pandas_dataframe(data)
+        else:
+            result._schema = schema
+
+        return result
+
     # ------------------------------------------------------------------------------------------------------------------
     # Dunder methods
     # ------------------------------------------------------------------------------------------------------------------

--- a/tests/safeds/data/tabular/containers/_table/test_from_pandas_dataframe.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_pandas_dataframe.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import pytest
+from safeds.data.tabular.containers import Table
+from safeds.data.tabular.typing import Integer, RealNumber, Schema, String
+
+
+@pytest.mark.parametrize(
+    ("dataframe", "schema", "expected"),
+    [
+        (
+            pd.DataFrame({"col1": [0]}),
+            Schema({"col1": Integer()}),
+            Schema({"col1": Integer()}),
+        ),
+        (
+            pd.DataFrame({"col1": [0], "col2": ["a"]}),
+            Schema({"col1": Integer(), "col2": String()}),
+            Schema({"col1": Integer(), "col2": String()}),
+        ),
+        (
+            pd.DataFrame({"col1": [0, 1.1]}),
+            Schema({"col1": String()}),
+            Schema({"col1": String()}),
+        ),
+        (
+            pd.DataFrame({"col1": [0, 1.1], "col2": ["a", "b"]}),
+            Schema({"col1": String(), "col2": String()}),
+            Schema({"col1": String(), "col2": String()}),
+        ),
+    ],
+    ids=[
+        "one row, one column",
+        "one row, two columns",
+        "two rows, one column",
+        "two rows, two columns",
+    ],
+)
+def test_should_use_the_schema_if_passed(dataframe: pd.DataFrame, schema: Schema, expected: Schema) -> None:
+    table = Table._from_pandas_dataframe(dataframe, schema)
+    assert table._schema == expected
+
+
+@pytest.mark.parametrize(
+    ("dataframe", "expected"),
+    [
+        (
+            pd.DataFrame({"col1": [0]}),
+            Schema({"col1": Integer()}),
+        ),
+        (
+            pd.DataFrame({"col1": [0], "col2": ["a"]}),
+            Schema({"col1": Integer(), "col2": String()}),
+        ),
+        (
+            pd.DataFrame({"col1": [0, 1.1]}),
+            Schema({"col1": RealNumber()}),
+        ),
+        (
+            pd.DataFrame({"col1": [0, 1.1], "col2": ["a", "b"]}),
+            Schema({"col1": RealNumber(), "col2": String()}),
+        ),
+    ],
+    ids=[
+        "one row, one column",
+        "one row, two columns",
+        "two rows, one column",
+        "two rows, two columns",
+    ],
+)
+def test_should_infer_the_schema_if_not_passed(dataframe: pd.DataFrame, expected: Schema) -> None:
+    table = Table._from_pandas_dataframe(dataframe)
+    assert table._schema == expected


### PR DESCRIPTION
### Summary of Changes

Add method `_from_pandas_dataframe` to create a `Table` from a `pandas.DataFrame`. This can be called internally instead of the constructor (once #256 is done), so we can provide a usable constructor.