### PR TITLE
feat: Remove warnings thrown in new `Transformer` methods

### DIFF
--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Any
 
 import pandas as pd
@@ -194,7 +193,6 @@ class Imputer(TableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("Imputer only changes data within columns, but does not add any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []
@@ -232,7 +230,6 @@ class Imputer(TableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("Imputer only changes data within columns, but does not remove any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 from sklearn.preprocessing import OrdinalEncoder as sk_OrdinalEncoder
 
 from safeds.data.tabular.containers import Table
@@ -143,7 +141,6 @@ class LabelEncoder(InvertibleTableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("LabelEncoder only changes data within columns, but does not add any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []
@@ -181,7 +178,6 @@ class LabelEncoder(InvertibleTableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("LabelEncoder only changes data within columns, but does not remove any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections import Counter
 from typing import Any
 
@@ -284,7 +283,6 @@ class OneHotEncoder(InvertibleTableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("OneHotEncoder only removes and adds, but does not change any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []

--- a/src/safeds/data/tabular/transformation/_range_scaler.py
+++ b/src/safeds/data/tabular/transformation/_range_scaler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import warnings
-
 from sklearn.preprocessing import MinMaxScaler as sk_MinMaxScaler
 
 from safeds.data.tabular.containers import Table
@@ -157,7 +155,6 @@ class RangeScaler(InvertibleTableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("RangeScaler only changes data within columns, but does not add any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []
@@ -195,7 +192,6 @@ class RangeScaler(InvertibleTableTransformer):
         TransformerNotFittedError
             If the transformer has not been fitted yet.
         """
-        warnings.warn("RangeScaler only changes data within columns, but does not remove any columns.", stacklevel=1)
         if not self.is_fitted():
             raise TransformerNotFittedError
         return []

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -210,10 +210,7 @@ class TestFitAndTransform:
 
     def test_get_names_of_added_columns(self) -> None:
         transformer = Imputer(strategy=Imputer.Strategy.Constant(1))
-        with pytest.warns(
-            UserWarning,
-            match="Imputer only changes data within columns, but does not add any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_added_columns()
 
         table = Table(
@@ -223,8 +220,7 @@ class TestFitAndTransform:
             },
         )
         transformer = transformer.fit(table, None)
-        with pytest.warns(UserWarning, match="Imputer only changes data within columns, but does not add any columns."):
-            assert transformer.get_names_of_added_columns() == []
+        assert transformer.get_names_of_added_columns() == []
 
     def test_get_names_of_changed_columns(self) -> None:
         transformer = Imputer(strategy=Imputer.Strategy.Constant(1))
@@ -241,10 +237,7 @@ class TestFitAndTransform:
 
     def test_get_names_of_removed_columns(self) -> None:
         transformer = Imputer(strategy=Imputer.Strategy.Constant(1))
-        with pytest.warns(
-            UserWarning,
-            match="Imputer only changes data within columns, but does not remove any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_removed_columns()
 
         table = Table(
@@ -254,8 +247,4 @@ class TestFitAndTransform:
             },
         )
         transformer = transformer.fit(table, None)
-        with pytest.warns(
-            UserWarning,
-            match="Imputer only changes data within columns, but does not remove any columns.",
-        ):
-            assert transformer.get_names_of_removed_columns() == []
+        assert transformer.get_names_of_removed_columns() == []

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -139,10 +139,7 @@ class TestFitAndTransform:
 
     def test_get_names_of_added_columns(self) -> None:
         transformer = LabelEncoder()
-        with pytest.warns(
-            UserWarning,
-            match="LabelEncoder only changes data within columns, but does not add any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_added_columns()
 
         table = Table(
@@ -151,11 +148,7 @@ class TestFitAndTransform:
             },
         )
         transformer = transformer.fit(table, None)
-        with pytest.warns(
-            UserWarning,
-            match="LabelEncoder only changes data within columns, but does not add any columns.",
-        ):
-            assert transformer.get_names_of_added_columns() == []
+        assert transformer.get_names_of_added_columns() == []
 
     def test_get_names_of_changed_columns(self) -> None:
         transformer = LabelEncoder()
@@ -171,10 +164,7 @@ class TestFitAndTransform:
 
     def test_get_names_of_removed_columns(self) -> None:
         transformer = LabelEncoder()
-        with pytest.warns(
-            UserWarning,
-            match="LabelEncoder only changes data within columns, but does not remove any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_removed_columns()
 
         table = Table(
@@ -183,11 +173,7 @@ class TestFitAndTransform:
             },
         )
         transformer = transformer.fit(table, None)
-        with pytest.warns(
-            UserWarning,
-            match="LabelEncoder only changes data within columns, but does not remove any columns.",
-        ):
-            assert transformer.get_names_of_removed_columns() == []
+        assert transformer.get_names_of_removed_columns() == []
 
 
 class TestInverseTransform:

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -228,20 +228,16 @@ class TestFitAndTransform:
 
     def test_get_names_of_changed_columns(self) -> None:
         transformer = OneHotEncoder()
-        with pytest.warns(
-            UserWarning,
-            match="OneHotEncoder only removes and adds, but does not change any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_changed_columns()
 
-        with pytest.warns(UserWarning, match="OneHotEncoder only removes and adds, but does not change any columns."):
-            table = Table(
-                {
-                    "a": ["b"],
-                },
-            )
-            transformer = transformer.fit(table, None)
-            assert transformer.get_names_of_changed_columns() == []
+        table = Table(
+            {
+                "a": ["b"],
+            },
+        )
+        transformer = transformer.fit(table, None)
+        assert transformer.get_names_of_changed_columns() == []
 
     def test_get_names_of_removed_columns(self) -> None:
         transformer = OneHotEncoder()

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -186,10 +186,7 @@ class TestFitAndTransform:
 
     def test_get_names_of_added_columns(self) -> None:
         transformer = RangeScaler()
-        with pytest.warns(
-            UserWarning,
-            match="RangeScaler only changes data within columns, but does not add any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_added_columns()
 
         table = Table(
@@ -198,11 +195,7 @@ class TestFitAndTransform:
             },
         )
         transformer = transformer.fit(table, None)
-        with pytest.warns(
-            UserWarning,
-            match="RangeScaler only changes data within columns, but does not add any columns.",
-        ):
-            assert transformer.get_names_of_added_columns() == []
+        assert transformer.get_names_of_added_columns() == []
 
     def test_get_names_of_changed_columns(self) -> None:
         transformer = RangeScaler()
@@ -218,10 +211,7 @@ class TestFitAndTransform:
 
     def test_get_names_of_removed_columns(self) -> None:
         transformer = RangeScaler()
-        with pytest.warns(
-            UserWarning,
-            match="RangeScaler only changes data within columns, but does not remove any columns.",
-        ), pytest.raises(TransformerNotFittedError):
+        with pytest.raises(TransformerNotFittedError):
             transformer.get_names_of_removed_columns()
 
         table = Table(
@@ -230,11 +220,7 @@ class TestFitAndTransform:
             },
         )
         transformer = transformer.fit(table, None)
-        with pytest.warns(
-            UserWarning,
-            match="RangeScaler only changes data within columns, but does not remove any columns.",
-        ):
-            assert transformer.get_names_of_removed_columns() == []
+        assert transformer.get_names_of_removed_columns() == []
 
 
 class TestInverseTransform:


### PR DESCRIPTION
Closes #323.

### Summary of Changes

Removed the warnings from `get_names_of_added_columns`, `get_names_of_changed_columns` and `get_names_of_removed_columns` in all transformers.
Updated tests accordingly.
