### PR TITLE
feat: Added ability to `Table.add_row` and `Table.add_rows` to allow new rows with different schemas

### DIFF
--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import functools
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, Tuple
 
 import pandas as pd
 
@@ -439,6 +440,37 @@ class Row(Mapping[str, Any]):
         Integer
         """
         return self._schema.get_column_type(column_name)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Transformations
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def sort_columns(self, comparator: Callable[[Tuple, Tuple], int] = lambda col1, col2: (col1[0] > col2[0])
+        - (col1[0] < col2[0])) -> Row:
+        """
+        Sort the columns of a `Row` with the given comparator and return a new `Row`.
+
+        The original row is not modified. The comparator is a function that takes two Tuples of (ColumnName: Value) `col1` and `col2` and
+        returns an integer:
+
+        * If `col1` should be ordered before `col2`, the function should return a negative number.
+        * If `col1` should be ordered after `col2`, the function should return a positive number.
+        * If the original order of `col1` and `col2` should be kept, the function should return 0.
+
+        If no comparator is given, the columns will be sorted alphabetically by their name.
+
+        Parameters
+        ----------
+        comparator : Callable[[Tuple, Tuple], int]
+            The function used to compare two Tuples of (ColumnName: Value).
+
+        Returns
+        -------
+        new_row : Row
+            A new row with sorted columns.
+        """
+        sorted_row_dict = dict(sorted(self.to_dict().items(), key=functools.cmp_to_key(comparator)))
+        return Row.from_dict(sorted_row_dict)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Conversion

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -446,7 +446,8 @@ class Row(Mapping[str, Any]):
     # ------------------------------------------------------------------------------------------------------------------
 
     def sort_columns(
-        self, comparator: Callable[[tuple, tuple], int] = lambda col1, col2: (col1[0] > col2[0]) - (col1[0] < col2[0]),
+        self,
+        comparator: Callable[[tuple, tuple], int] = lambda col1, col2: (col1[0] > col2[0]) - (col1[0] < col2[0]),
     ) -> Row:
         """
         Sort the columns of a `Row` with the given comparator and return a new `Row`.

--- a/src/safeds/data/tabular/containers/_row.py
+++ b/src/safeds/data/tabular/containers/_row.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import functools
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Callable, Tuple
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
@@ -264,7 +264,7 @@ class Row(Mapping[str, Any]):
         >>> repr(row)
         "Row({'a': 1})"
         """
-        return f"Row({str(self)})"
+        return f"Row({self!s})"
 
     def __str__(self) -> str:
         """
@@ -445,8 +445,9 @@ class Row(Mapping[str, Any]):
     # Transformations
     # ------------------------------------------------------------------------------------------------------------------
 
-    def sort_columns(self, comparator: Callable[[Tuple, Tuple], int] = lambda col1, col2: (col1[0] > col2[0])
-        - (col1[0] < col2[0])) -> Row:
+    def sort_columns(
+        self, comparator: Callable[[tuple, tuple], int] = lambda col1, col2: (col1[0] > col2[0]) - (col1[0] < col2[0]),
+    ) -> Row:
         """
         Sort the columns of a `Row` with the given comparator and return a new `Row`.
 

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -710,7 +710,9 @@ class Table:
         sorted_rows = []
         for row in rows:
             sorted_rows.append(
-                row.sort_columns(lambda col1, col2: self.column_names.index(col2[0]) - self.column_names.index(col1[0])),
+                row.sort_columns(
+                    lambda col1, col2: self.column_names.index(col2[0]) - self.column_names.index(col1[0]),
+                ),
             )
         rows = sorted_rows
 

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -696,11 +696,11 @@ class Table:
         UnknownColumnNameError
             If at least one of the rows have different column names than the table.
         """
-        if self.number_of_columns == 0:
-            return Table.from_rows(rows)
-
         if isinstance(rows, Table):
             rows = rows.to_rows()
+
+        if self.number_of_columns == 0:
+            return Table.from_rows(rows)
 
         missing_col_names = set()
         for row in rows:

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -702,16 +702,16 @@ class Table:
         if isinstance(rows, Table):
             rows = rows.to_rows()
 
-        sorted_rows = list()
-        for row in rows:
-            sorted_rows.append(row.sort_columns(lambda col1, col2: self.column_names.index(col2[0]) - self.column_names.index(col1[0])))
-        rows = sorted_rows
-
         missing_col_names = set()
         for row in rows:
             missing_col_names.update(set(self.column_names) - set(row.column_names))
         if len(missing_col_names) > 0:
             raise UnknownColumnNameError(list(missing_col_names))
+
+        sorted_rows = list()
+        for row in rows:
+            sorted_rows.append(row.sort_columns(lambda col1, col2: self.column_names.index(col2[0]) - self.column_names.index(col1[0])))
+        rows = sorted_rows
 
         result = self._data
         row_frames = (row._data for row in rows)

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -245,23 +245,28 @@ class Table:
 
         Raises
         ------
-        SchemaMismatchError
-            If any of the row schemas does not match with the others.
+        UnknownColumnNameError
+            If any of the row column names does not match with the first row.
         """
         if len(rows) == 0:
             return Table._from_pandas_dataframe(pd.DataFrame())
 
-        schema_compare: Schema = rows[0]._schema
+        column_names_compare: list = list(rows[0].column_names)
+        unknown_column_names = set()
         row_array: list[pd.DataFrame] = []
 
         for row in rows:
-            if schema_compare != row._schema:
-                raise SchemaMismatchError
+            unknown_column_names.update(set(column_names_compare) - set(row.column_names))
             row_array.append(row._data)
+        if len(unknown_column_names) > 0:
+            raise UnknownColumnNameError(list(unknown_column_names))
 
         dataframe: DataFrame = pd.concat(row_array, ignore_index=True)
-        dataframe.columns = schema_compare.column_names
-        return Table._from_pandas_dataframe(dataframe)
+        dataframe.columns = column_names_compare
+
+        schema = Schema.merge_multiple_schemas(list(row.schema for row in rows))
+
+        return Table._from_pandas_dataframe(dataframe, schema)
 
     @staticmethod
     def _from_pandas_dataframe(data: pd.DataFrame, schema: Schema | None = None) -> Table:
@@ -636,7 +641,8 @@ class Table:
         """
         Add a row to the table.
 
-        This table is not modified.
+        The order of columns of the new row will be adjusted to the order of columns in the table.
+        This table will contain the merged schema.
 
         Parameters
         ----------
@@ -650,21 +656,30 @@ class Table:
 
         Raises
         ------
-        SchemaMismatchError
-            If the schema of the row does not match the table schema.
+        UnknownColumnNameError
+            If the row has different column names than the table.
         """
-        if self._schema != row.schema:
-            raise SchemaMismatchError
+        if self.number_of_columns == 0:
+            return Table.from_rows([row])
+
+        if len(set(self.column_names) - set(row.column_names)) > 0:
+            raise UnknownColumnNameError(list(set(self.column_names) - set(row.column_names)))
+
+        row = row.sort_columns(lambda col1, col2: self.column_names.index(col2[0]) - self.column_names.index(col1[0]))
 
         new_df = pd.concat([self._data, row._data]).infer_objects()
         new_df.columns = self.column_names
-        return Table._from_pandas_dataframe(new_df)
+
+        schema = Schema.merge_multiple_schemas([self.schema, row.schema])
+
+        return Table._from_pandas_dataframe(new_df, schema)
 
     def add_rows(self, rows: list[Row] | Table) -> Table:
         """
         Add multiple rows to a table.
 
-        This table is not modified.
+        The order of columns of the new rows will be adjusted to the order of columns in the table.
+        This table will contain the merged schema.
 
         Parameters
         ----------
@@ -678,21 +693,35 @@ class Table:
 
         Raises
         ------
-        SchemaMismatchError
-            If the schema of on of the row does not match the table schema.
+        UnknownColumnNameError
+            If at least one of the rows have different column names than the table.
         """
+        if self.number_of_columns == 0:
+            return Table.from_rows(rows)
+
         if isinstance(rows, Table):
             rows = rows.to_rows()
-        result = self._data
-        for row in rows:
-            if self._schema != row.schema:
-                raise SchemaMismatchError
 
+        sorted_rows = list()
+        for row in rows:
+            sorted_rows.append(row.sort_columns(lambda col1, col2: self.column_names.index(col2[0]) - self.column_names.index(col1[0])))
+        rows = sorted_rows
+
+        missing_col_names = set()
+        for row in rows:
+            missing_col_names.update(set(self.column_names) - set(row.column_names))
+        if len(missing_col_names) > 0:
+            raise UnknownColumnNameError(list(missing_col_names))
+
+        result = self._data
         row_frames = (row._data for row in rows)
 
         result = pd.concat([result, *row_frames]).infer_objects()
         result.columns = self.column_names
-        return Table._from_pandas_dataframe(result)
+
+        schema = Schema.merge_multiple_schemas([self.schema] + list(row.schema for row in rows))
+
+        return Table._from_pandas_dataframe(result, schema)
 
     def filter_rows(self, query: Callable[[Row], bool]) -> Table:
         """
@@ -1024,8 +1053,6 @@ class Table:
         * If the original order of `col1` and `col2` should be kept, the function should return 0.
 
         If no comparator is given, the columns will be sorted alphabetically by their name.
-
-        This table is not modified.
 
         Parameters
         ----------

--- a/src/safeds/data/tabular/typing/_column_type.py
+++ b/src/safeds/data/tabular/typing/_column_type.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
 class ColumnType(ABC):
     """Abstract base class for column types."""
 
+    @abstractmethod
+    def __init__(self, is_nullable: bool = False):
+        pass
+
     @staticmethod
     def _from_numpy_data_type(data_type: np.dtype) -> ColumnType:
         """

--- a/src/safeds/data/tabular/typing/_schema.py
+++ b/src/safeds/data/tabular/typing/_schema.py
@@ -223,7 +223,7 @@ class Schema:
         return dict(self._schema)  # defensive copy
 
     @staticmethod
-    def merge_multiple_schemas(schemas: list[Schema]):
+    def merge_multiple_schemas(schemas: list[Schema]) -> Schema:
         """
         Merge multiple schemas into one.
 
@@ -265,9 +265,7 @@ class Schema:
                         nullable = True
                     if isinstance(schema_dict[col_name], type(schema.get_column_type(col_name))):
                         if schema.get_column_type(col_name).is_nullable() and not schema_dict[col_name].is_nullable():
-                            new_type = deepcopy(schema.get_column_type(col_name))
-                            new_type._is_nullable = nullable
-                            schema_dict[col_name] = new_type
+                            schema_dict[col_name] = type(schema.get_column_type(col_name))(nullable)
                         continue
                     if (isinstance(schema_dict[col_name], RealNumber) and isinstance(schema.get_column_type(col_name), Integer)) or (isinstance(schema_dict[col_name], Integer) and isinstance(schema.get_column_type(col_name), RealNumber)):
                         schema_dict[col_name] = RealNumber(nullable)

--- a/src/safeds/data/tabular/typing/_schema.py
+++ b/src/safeds/data/tabular/typing/_schema.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from safeds.data.tabular.typing import Integer, RealNumber, Anything
+from safeds.data.tabular.typing import Anything, Integer, RealNumber
 from safeds.data.tabular.typing._column_type import ColumnType
 from safeds.exceptions import UnknownColumnNameError
 
@@ -97,7 +96,7 @@ class Schema:
         >>> repr(schema)
         "Schema({'A': Integer})"
         """
-        return f"Schema({str(self)})"
+        return f"Schema({self!s})"
 
     def __str__(self) -> str:
         """
@@ -259,7 +258,7 @@ class Schema:
             raise UnknownColumnNameError(list(missing_col_names))
         for schema in schemas:
             if schema_dict != schema._schema:
-                for col_name in schema_dict.keys():
+                for col_name in schema_dict:
                     nullable = False
                     if schema_dict[col_name].is_nullable() or schema.get_column_type(col_name).is_nullable():
                         nullable = True
@@ -267,7 +266,13 @@ class Schema:
                         if schema.get_column_type(col_name).is_nullable() and not schema_dict[col_name].is_nullable():
                             schema_dict[col_name] = type(schema.get_column_type(col_name))(nullable)
                         continue
-                    if (isinstance(schema_dict[col_name], RealNumber) and isinstance(schema.get_column_type(col_name), Integer)) or (isinstance(schema_dict[col_name], Integer) and isinstance(schema.get_column_type(col_name), RealNumber)):
+                    if (
+                        isinstance(schema_dict[col_name], RealNumber)
+                        and isinstance(schema.get_column_type(col_name), Integer)
+                    ) or (
+                        isinstance(schema_dict[col_name], Integer)
+                        and isinstance(schema.get_column_type(col_name), RealNumber)
+                    ):
                         schema_dict[col_name] = RealNumber(nullable)
                         continue
                     schema_dict[col_name] = Anything(nullable)

--- a/src/safeds/data/tabular/typing/_schema.py
+++ b/src/safeds/data/tabular/typing/_schema.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from safeds.data.tabular.typing import Integer, RealNumber, Anything
 from safeds.data.tabular.typing._column_type import ColumnType
 from safeds.exceptions import UnknownColumnNameError
 
@@ -219,6 +221,59 @@ class Schema:
         {'A': Integer, 'B': String}
         """
         return dict(self._schema)  # defensive copy
+
+    @staticmethod
+    def merge_multiple_schemas(schemas: list[Schema]):
+        """
+        Merge multiple schemas into one.
+
+        For each type missmatch the new schema will have the least common supertype.
+
+        The type hierarchy is as follows:
+        * Anything
+            * RealNumber
+                * Integer
+            * Boolean
+            * String
+
+        Parameters
+        ----------
+        schemas : list[Schema]
+            the list of schemas you want to merge
+
+        Returns
+        -------
+        schema : Schema
+            the new merged schema
+
+        Raises
+        ------
+        UnknownColumnNameError
+            if not all schemas have the same column names
+        """
+        schema_dict = schemas[0]._schema
+        missing_col_names = set()
+        for schema in schemas:
+            missing_col_names.update(set(schema.column_names) - set(schema_dict.keys()))
+        if len(missing_col_names) > 0:
+            raise UnknownColumnNameError(list(missing_col_names))
+        for schema in schemas:
+            if schema_dict != schema._schema:
+                for col_name in schema_dict.keys():
+                    nullable = False
+                    if schema_dict[col_name].is_nullable() or schema.get_column_type(col_name).is_nullable():
+                        nullable = True
+                    if isinstance(schema_dict[col_name], type(schema.get_column_type(col_name))):
+                        if schema.get_column_type(col_name).is_nullable() and not schema_dict[col_name].is_nullable():
+                            new_type = deepcopy(schema.get_column_type(col_name))
+                            new_type._is_nullable = nullable
+                            schema_dict[col_name] = new_type
+                        continue
+                    if (isinstance(schema_dict[col_name], RealNumber) and isinstance(schema.get_column_type(col_name), Integer)) or (isinstance(schema_dict[col_name], Integer) and isinstance(schema.get_column_type(col_name), RealNumber)):
+                        schema_dict[col_name] = RealNumber(nullable)
+                        continue
+                    schema_dict[col_name] = Anything(nullable)
+        return Schema(schema_dict)
 
     # ------------------------------------------------------------------------------------------------------------------
     # IPython Integration

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -1,26 +1,31 @@
 import pytest
 from _pytest.python_api import raises
 from safeds.data.tabular.containers import Row, Table
-from safeds.data.tabular.typing import Schema, Integer, Anything
+from safeds.data.tabular.typing import Anything, Integer, Schema
 from safeds.exceptions import UnknownColumnNameError
 
 
 @pytest.mark.parametrize(
     ("table", "row", "expected", "expected_schema"),
     [
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-         Row({"col1": 5, "col2": 6}),
-         Table({"col1": [1, 2, 1, 5], "col2": [1, 2, 4, 6]}),
-         Schema({"col1": Integer(), "col2": Integer()})),
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-         Row({"col1": "5", "col2": 6}),
-         Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, 6]}),
-         Schema({"col1": Anything(), "col2": Integer()})),
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-         Table.from_rows([Row({"col1": "5", "col2": None}),
-                          Row({"col1": "5", "col2": 2})]).get_row(0),
-         Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, None]}),
-         Schema({"col1": Anything(), "col2": Integer(is_nullable=True)})),
+        (
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            Row({"col1": 5, "col2": 6}),
+            Table({"col1": [1, 2, 1, 5], "col2": [1, 2, 4, 6]}),
+            Schema({"col1": Integer(), "col2": Integer()}),
+        ),
+        (
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            Row({"col1": "5", "col2": 6}),
+            Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, 6]}),
+            Schema({"col1": Anything(), "col2": Integer()}),
+        ),
+        (
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            Table.from_rows([Row({"col1": "5", "col2": None}), Row({"col1": "5", "col2": 2})]).get_row(0),
+            Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, None]}),
+            Schema({"col1": Anything(), "col2": Integer(is_nullable=True)}),
+        ),
     ],
     ids=["added row", "different schemas", "different schemas and nullable"],
 )
@@ -33,8 +38,14 @@ def test_should_add_row(table: Table, row: Row, expected: Table, expected_schema
 
 @pytest.mark.parametrize(
     ("table", "row", "expected_error_msg"),
-    [(Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Row({"col1": 5, "col3": "Hallo"}), r"Could not find column\(s\) 'col2'")],
-    ids=["unknown column col2 in row"]
+    [
+        (
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            Row({"col1": 5, "col3": "Hallo"}),
+            r"Could not find column\(s\) 'col2'",
+        ),
+    ],
+    ids=["unknown column col2 in row"],
 )
 def test_should_raise_error_if_row_column_names_invalid(table: Table, row: Row, expected_error_msg: str) -> None:
     with raises(UnknownColumnNameError, match=expected_error_msg):

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -20,7 +20,7 @@ from safeds.exceptions import UnknownColumnNameError
          Table.from_rows([Row({"col1": "5", "col2": None}),
                           Row({"col1": "5", "col2": 2})]).get_row(0),
          Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, None]}),
-         Schema({"col1": Anything(), "col2": Integer(False)})),
+         Schema({"col1": Anything(), "col2": Integer(is_nullable=True)})),
     ],
     ids=["added row", "different schemas", "different schemas and nullable"],
 )
@@ -36,6 +36,6 @@ def test_should_add_row(table: Table, row: Row, expected: Table, expected_schema
     [(Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Row({"col1": 5, "col3": "Hallo"}), r"Could not find column\(s\) 'col2'")],
     ids=["unknown column col2 in row"]
 )
-def test_should_raise_error_if_row_column_names_invalid(table, row, expected_error_msg) -> None:
+def test_should_raise_error_if_row_column_names_invalid(table: Table, row: Row, expected_error_msg: str) -> None:
     with raises(UnknownColumnNameError, match=expected_error_msg):
         table.add_row(row)

--- a/tests/safeds/data/tabular/containers/_table/test_add_row.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_row.py
@@ -1,25 +1,41 @@
 import pytest
 from _pytest.python_api import raises
 from safeds.data.tabular.containers import Row, Table
-from safeds.exceptions import SchemaMismatchError
+from safeds.data.tabular.typing import Schema, Integer, Anything
+from safeds.exceptions import UnknownColumnNameError
 
 
 @pytest.mark.parametrize(
-    ("table", "row"),
+    ("table", "row", "expected", "expected_schema"),
     [
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Row({"col1": 5, "col2": 6})),
+        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+         Row({"col1": 5, "col2": 6}),
+         Table({"col1": [1, 2, 1, 5], "col2": [1, 2, 4, 6]}),
+         Schema({"col1": Integer(), "col2": Integer()})),
+        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+         Row({"col1": "5", "col2": 6}),
+         Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, 6]}),
+         Schema({"col1": Anything(), "col2": Integer()})),
+        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+         Table.from_rows([Row({"col1": "5", "col2": None}),
+                          Row({"col1": "5", "col2": 2})]).get_row(0),
+         Table({"col1": [1, 2, 1, "5"], "col2": [1, 2, 4, None]}),
+         Schema({"col1": Anything(), "col2": Integer(False)})),
     ],
-    ids=["added row"],
+    ids=["added row", "different schemas", "different schemas and nullable"],
 )
-def test_should_add_row(table: Table, row: Row) -> None:
+def test_should_add_row(table: Table, row: Row, expected: Table, expected_schema: Schema) -> None:
     table = table.add_row(row)
     assert table.number_of_rows == 4
-    assert table.get_row(3) == row
-    assert table.schema == row._schema
+    assert table.schema == expected_schema
+    assert table == expected
 
 
-def test_should_raise_error_if_row_schema_invalid() -> None:
-    table1 = Table({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    row = Row({"col1": 5, "col2": "Hallo"})
-    with raises(SchemaMismatchError, match=r"Failed because at least two schemas didn't match."):
-        table1.add_row(row)
+@pytest.mark.parametrize(
+    ("table", "row", "expected_error_msg"),
+    [(Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}), Row({"col1": 5, "col3": "Hallo"}), r"Could not find column\(s\) 'col2'")],
+    ids=["unknown column col2 in row"]
+)
+def test_should_raise_error_if_row_column_names_invalid(table, row, expected_error_msg) -> None:
+    with raises(UnknownColumnNameError, match=expected_error_msg):
+        table.add_row(row)

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -11,11 +11,17 @@ from safeds.exceptions import UnknownColumnNameError
             [Row({"col1": "d", "col2": 6}), Row({"col1": "e", "col2": 8})],
             Table({"col1": ["a", "b", "c", "d", "e"], "col2": [1, 2, 4, 6, 8]}),
         ),
+        (
+            Table({"col1": ["a", "b", "c"], "col2": [1, 2, 4]}),
+            [Row({"col1": "d", "col2": 6}), Row({"col1": "e", "col2": "f"})],
+            Table({"col1": ["a", "b", "c", "d", "e"], "col2": [1, 2, 4, 6, "f"]}),
+        ),
     ],
-    ids=["Rows with string and integer values"],
+    ids=["Rows with string and integer values", "different schema"],
 )
 def test_should_add_rows(table1: Table, rows: list[Row], table2: Table) -> None:
     table1 = table1.add_rows(rows)
+    assert table1.schema == table2.schema
     assert table1 == table2
 
 
@@ -27,11 +33,17 @@ def test_should_add_rows(table1: Table, rows: list[Row], table2: Table) -> None:
             Table({"col1": [5, 7], "col2": [6, 8]}),
             Table({"col1": [1, 2, 1, 5, 7], "col2": [1, 2, 4, 6, 8]}),
         ),
+        (
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            Table({"col1": [5, "7"], "col2": [6, None]}),
+            Table({"col1": [1, 2, 1, 5, "7"], "col2": [1, 2, 4, 6, None]}),
+        ),
     ],
-    ids=["Rows from table"],
+    ids=["Rows from table", "different schema"],
 )
 def test_should_add_rows_from_table(table1: Table, table2: Table, expected: Table) -> None:
     table1 = table1.add_rows(table2)
+    assert table1.schema == expected.schema
     assert table1 == expected
 
 
@@ -40,9 +52,10 @@ def test_should_add_rows_from_table(table1: Table, table2: Table, expected: Tabl
     [
         (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
          [Row({"col1": 2, "col3": 4}), Row({"col1": 5, "col2": "Hallo"})],
-         r"aa"
+         r"Could not find column\(s\) 'col2'"
          ),
-    ]
+    ],
+    ids=["column names do not match"]
 )
 def test_should_raise_error_if_row_column_names_invalid(table: Table, rows: list[Row], expected_error_msg: str) -> None:
     with pytest.raises(UnknownColumnNameError, match=expected_error_msg):

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -50,12 +50,13 @@ def test_should_add_rows_from_table(table1: Table, table2: Table, expected: Tabl
 @pytest.mark.parametrize(
     ("table", "rows", "expected_error_msg"),
     [
-        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
-         [Row({"col1": 2, "col3": 4}), Row({"col1": 5, "col2": "Hallo"})],
-         r"Could not find column\(s\) 'col2'"
-         ),
+        (
+            Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+            [Row({"col1": 2, "col3": 4}), Row({"col1": 5, "col2": "Hallo"})],
+            r"Could not find column\(s\) 'col2'",
+        ),
     ],
-    ids=["column names do not match"]
+    ids=["column names do not match"],
 )
 def test_should_raise_error_if_row_column_names_invalid(table: Table, rows: list[Row], expected_error_msg: str) -> None:
     with pytest.raises(UnknownColumnNameError, match=expected_error_msg):

--- a/tests/safeds/data/tabular/containers/_table/test_add_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_add_rows.py
@@ -1,6 +1,6 @@
 import pytest
 from safeds.data.tabular.containers import Row, Table
-from safeds.exceptions import SchemaMismatchError
+from safeds.exceptions import UnknownColumnNameError
 
 
 @pytest.mark.parametrize(
@@ -35,8 +35,15 @@ def test_should_add_rows_from_table(table1: Table, table2: Table, expected: Tabl
     assert table1 == expected
 
 
-def test_should_raise_error_if_row_schema_invalid() -> None:
-    table1 = Table({"col1": [1, 2, 1], "col2": [1, 2, 4]})
-    row = [Row({"col1": 2, "col2": 4}), Row({"col1": 5, "col2": "Hallo"})]
-    with pytest.raises(SchemaMismatchError, match=r"Failed because at least two schemas didn't match."):
-        table1.add_rows(row)
+@pytest.mark.parametrize(
+    ("table", "rows", "expected_error_msg"),
+    [
+        (Table({"col1": [1, 2, 1], "col2": [1, 2, 4]}),
+         [Row({"col1": 2, "col3": 4}), Row({"col1": 5, "col2": "Hallo"})],
+         r"aa"
+         ),
+    ]
+)
+def test_should_raise_error_if_row_column_names_invalid(table: Table, rows: list[Row], expected_error_msg: str) -> None:
+    with pytest.raises(UnknownColumnNameError, match=expected_error_msg):
+        table.add_rows(rows)

--- a/tests/safeds/data/tabular/containers/_table/test_from_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_rows.py
@@ -1,6 +1,6 @@
 import pytest
 from safeds.data.tabular.containers import Row, Table
-from safeds.exceptions import SchemaMismatchError
+from safeds.exceptions import UnknownColumnNameError
 
 
 @pytest.mark.parametrize(
@@ -24,14 +24,37 @@ from safeds.exceptions import SchemaMismatchError
                 },
             ),
         ),
+        (
+            [
+                Row({"A": 1, "B": 4, "C": "d"}),
+                Row({"A": 2, "B": 5, "C": "e"}),
+                Row({"A": 3, "B": "6", "C": "f"}),
+            ],
+            Table(
+                {
+                    "A": [1, 2, 3],
+                    "B": [4, 5, "6"],
+                    "C": ["d", "e", "f"],
+                },
+            ),
+        ),
     ],
-    ids=["empty", "non-empty"],
+    ids=["empty", "non-empty", "different schemas"],
 )
 def test_should_create_table_from_rows(rows: list[Row], expected: Table) -> None:
-    assert Table.from_rows(rows) == expected
+    table = Table.from_rows(rows)
+    assert table.schema == expected.schema
+    assert table == expected
 
 
-def test_should_raise_error_if_mismatching_schema() -> None:
-    rows = [Row({"A": 1, "B": 2}), Row({"A": 2, "B": "a"})]
-    with pytest.raises(SchemaMismatchError, match=r"Failed because at least two schemas didn't match."):
+@pytest.mark.parametrize(
+    ("rows", "expected_error_msg"),
+    [
+        (
+            [Row({"A": 1, "B": 2}), Row({"A": 2, "C": 4})], r"Could not find column\(s\) 'B'"
+        )
+    ]
+)
+def test_should_raise_error_if_unknown_column_names(rows: list[Row], expected_error_msg: str) -> None:
+    with pytest.raises(UnknownColumnNameError, match=expected_error_msg):
         Table.from_rows(rows)

--- a/tests/safeds/data/tabular/containers/_table/test_from_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_from_rows.py
@@ -49,11 +49,7 @@ def test_should_create_table_from_rows(rows: list[Row], expected: Table) -> None
 
 @pytest.mark.parametrize(
     ("rows", "expected_error_msg"),
-    [
-        (
-            [Row({"A": 1, "B": 2}), Row({"A": 2, "C": 4})], r"Could not find column\(s\) 'B'"
-        )
-    ]
+    [([Row({"A": 1, "B": 2}), Row({"A": 2, "C": 4})], r"Could not find column\(s\) 'B'")],
 )
 def test_should_raise_error_if_unknown_column_names(rows: list[Row], expected_error_msg: str) -> None:
     with pytest.raises(UnknownColumnNameError, match=expected_error_msg):

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import pytest
-from safeds.data.tabular.typing import Boolean, ColumnType, Integer, RealNumber, Schema, String, Anything
+from safeds.data.tabular.typing import Anything, Boolean, ColumnType, Integer, RealNumber, Schema, String
 from safeds.exceptions import UnknownColumnNameError
 
 if TYPE_CHECKING:
@@ -238,10 +238,8 @@ class TestToDict:
 class TestMergeMultipleSchemas:
     @pytest.mark.parametrize(
         ("schemas", "error_msg_regex"),
-        [
-            ([Schema({"Column1": Anything()}), Schema({"Column2": Anything()})], r"Could not find column\(s\) 'Column2'")
-        ],
-        ids=["different_column_names"]
+        [([Schema({"Column1": Anything()}), Schema({"Column2": Anything()})], r"Could not find column\(s\) 'Column2'")],
+        ids=["different_column_names"],
     )
     def test_should_raise_if_column_names_are_different(self, schemas: list[Schema], error_msg_regex: str) -> None:
         with pytest.raises(UnknownColumnNameError, match=error_msg_regex):
@@ -265,38 +263,126 @@ class TestMergeMultipleSchemas:
             ([Schema({"Column1": Boolean()}), Schema({"Column1": String()})], Schema({"Column1": Anything()})),
             ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
             ([Schema({"Column1": String()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
-
-            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Integer()})], Schema({"Column1": Integer(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(is_nullable=True)})),
-            ([Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Boolean(is_nullable=True)})),
-            ([Schema({"Column1": String(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": String(is_nullable=True)})),
-            ([Schema({"Column1": Anything(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(is_nullable=True)})),
-            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": String(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
-
-            ([Schema({"Column1": Integer()}), Schema({"Column1": Integer(is_nullable=True)})], Schema({"Column1": Integer(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": RealNumber(is_nullable=True)})], Schema({"Column1": RealNumber(is_nullable=True)})),
-            ([Schema({"Column1": Boolean()}), Schema({"Column1": Boolean(is_nullable=True)})], Schema({"Column1": Boolean(is_nullable=True)})),
-            ([Schema({"Column1": String()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": String(is_nullable=True)})),
-            ([Schema({"Column1": Anything()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": RealNumber(is_nullable=True)})], Schema({"Column1": RealNumber(is_nullable=True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": Boolean(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Boolean(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Boolean()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
-            ([Schema({"Column1": String()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            (
+                [Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Integer()})],
+                Schema({"Column1": Integer(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": RealNumber()})],
+                Schema({"Column1": RealNumber(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": Boolean()})],
+                Schema({"Column1": Boolean(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": String(is_nullable=True)}), Schema({"Column1": String()})],
+                Schema({"Column1": String(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Anything(is_nullable=True)}), Schema({"Column1": Anything()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": RealNumber()})],
+                Schema({"Column1": RealNumber(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Boolean()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": String()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Anything()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": Boolean()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": String()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": Anything()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": String()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": Anything()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": String(is_nullable=True)}), Schema({"Column1": Anything()})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer()}), Schema({"Column1": Integer(is_nullable=True)})],
+                Schema({"Column1": Integer(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber()}), Schema({"Column1": RealNumber(is_nullable=True)})],
+                Schema({"Column1": RealNumber(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Boolean()}), Schema({"Column1": Boolean(is_nullable=True)})],
+                Schema({"Column1": Boolean(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": String()}), Schema({"Column1": String(is_nullable=True)})],
+                Schema({"Column1": String(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Anything()}), Schema({"Column1": Anything(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer()}), Schema({"Column1": RealNumber(is_nullable=True)})],
+                Schema({"Column1": RealNumber(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer()}), Schema({"Column1": Boolean(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer()}), Schema({"Column1": String(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Integer()}), Schema({"Column1": Anything(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber()}), Schema({"Column1": Boolean(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber()}), Schema({"Column1": String(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": RealNumber()}), Schema({"Column1": Anything(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Boolean()}), Schema({"Column1": String(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": Boolean()}), Schema({"Column1": Anything(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
+            (
+                [Schema({"Column1": String()}), Schema({"Column1": Anything(is_nullable=True)})],
+                Schema({"Column1": Anything(is_nullable=True)}),
+            ),
         ],
         ids=[
             "Integer Integer",
@@ -314,7 +400,6 @@ class TestMergeMultipleSchemas:
             "Boolean String",
             "Boolean Anything",
             "String Anything",
-
             "Integer(null) Integer",
             "RealNumber(null) RealNumber",
             "Boolean(null) Boolean",
@@ -330,7 +415,6 @@ class TestMergeMultipleSchemas:
             "Boolean(null) String",
             "Boolean(null) Anything",
             "String(null) Anything",
-
             "Integer Integer(null)",
             "RealNumber RealNumber(null)",
             "Boolean Boolean(null)",
@@ -346,12 +430,14 @@ class TestMergeMultipleSchemas:
             "Boolean String(null)",
             "Boolean Anything(null)",
             "String Anything(null)",
-        ]
+        ],
     )
     def test_should_return_merged_schema(self, schemas: list[Schema], expected: Schema) -> None:
         assert Schema.merge_multiple_schemas(schemas) == expected
         schemas.reverse()
-        assert Schema.merge_multiple_schemas(schemas) == expected  # test the reversed list because the first parameter is handled differently
+        assert (
+            Schema.merge_multiple_schemas(schemas) == expected
+        )  # test the reversed list because the first parameter is handled differently
 
 
 class TestReprMarkdown:

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -243,7 +243,7 @@ class TestMergeMultipleSchemas:
         ],
         ids=["different_column_names"]
     )
-    def test_should_raise_if_column_names_are_different(self, schemas: list[Schema], error_msg_regex: str):
+    def test_should_raise_if_column_names_are_different(self, schemas: list[Schema], error_msg_regex: str) -> None:
         with pytest.raises(UnknownColumnNameError, match=error_msg_regex):
             Schema.merge_multiple_schemas(schemas)
 
@@ -266,37 +266,37 @@ class TestMergeMultipleSchemas:
             ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
             ([Schema({"Column1": String()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
 
-            ([Schema({"Column1": Integer(True)}), Schema({"Column1": Integer()})], Schema({"Column1": Integer(True)})),
-            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(True)})),
-            ([Schema({"Column1": Boolean(True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Boolean(True)})),
-            ([Schema({"Column1": String(True)}), Schema({"Column1": String()})], Schema({"Column1": String(True)})),
-            ([Schema({"Column1": Anything(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Integer(True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(True)})),
-            ([Schema({"Column1": Integer(True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Integer(True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Integer(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Boolean(True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Boolean(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": String(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Integer()})], Schema({"Column1": Integer(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(is_nullable=True)})),
+            ([Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Boolean(is_nullable=True)})),
+            ([Schema({"Column1": String(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": String(is_nullable=True)})),
+            ([Schema({"Column1": Anything(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(is_nullable=True)})),
+            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Integer(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Boolean(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": String(is_nullable=True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(is_nullable=True)})),
 
-            ([Schema({"Column1": Integer()}), Schema({"Column1": Integer(True)})], Schema({"Column1": Integer(True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": RealNumber(True)})], Schema({"Column1": RealNumber(True)})),
-            ([Schema({"Column1": Boolean()}), Schema({"Column1": Boolean(True)})], Schema({"Column1": Boolean(True)})),
-            ([Schema({"Column1": String()}), Schema({"Column1": String(True)})], Schema({"Column1": String(True)})),
-            ([Schema({"Column1": Anything()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": RealNumber(True)})], Schema({"Column1": RealNumber(True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": Boolean(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": String(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Integer()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Boolean(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": String(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Boolean()}), Schema({"Column1": String(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
-            ([Schema({"Column1": String()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Integer(is_nullable=True)})], Schema({"Column1": Integer(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": RealNumber(is_nullable=True)})], Schema({"Column1": RealNumber(is_nullable=True)})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": Boolean(is_nullable=True)})], Schema({"Column1": Boolean(is_nullable=True)})),
+            ([Schema({"Column1": String()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": String(is_nullable=True)})),
+            ([Schema({"Column1": Anything()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": RealNumber(is_nullable=True)})], Schema({"Column1": RealNumber(is_nullable=True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Boolean(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Boolean(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": String(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
+            ([Schema({"Column1": String()}), Schema({"Column1": Anything(is_nullable=True)})], Schema({"Column1": Anything(is_nullable=True)})),
         ],
         ids=[
             "Integer Integer",
@@ -348,7 +348,7 @@ class TestMergeMultipleSchemas:
             "String Anything(null)",
         ]
     )
-    def test_should_return_merged_schema(self, schemas: list[Schema], expected: Schema):
+    def test_should_return_merged_schema(self, schemas: list[Schema], expected: Schema) -> None:
         assert Schema.merge_multiple_schemas(schemas) == expected
         schemas.reverse()
         assert Schema.merge_multiple_schemas(schemas) == expected  # test the reversed list because the first parameter is handled differently

--- a/tests/safeds/data/tabular/typing/test_schema.py
+++ b/tests/safeds/data/tabular/typing/test_schema.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 import pytest
-from safeds.data.tabular.typing import Boolean, ColumnType, Integer, RealNumber, Schema, String
+from safeds.data.tabular.typing import Boolean, ColumnType, Integer, RealNumber, Schema, String, Anything
 from safeds.exceptions import UnknownColumnNameError
 
 if TYPE_CHECKING:
@@ -233,6 +233,125 @@ class TestToDict:
     )
     def test_should_return_dict_for_schema(self, schema: Schema, expected: str) -> None:
         assert schema.to_dict() == expected
+
+
+class TestMergeMultipleSchemas:
+    @pytest.mark.parametrize(
+        ("schemas", "error_msg_regex"),
+        [
+            ([Schema({"Column1": Anything()}), Schema({"Column2": Anything()})], r"Could not find column\(s\) 'Column2'")
+        ],
+        ids=["different_column_names"]
+    )
+    def test_should_raise_if_column_names_are_different(self, schemas: list[Schema], error_msg_regex: str):
+        with pytest.raises(UnknownColumnNameError, match=error_msg_regex):
+            Schema.merge_multiple_schemas(schemas)
+
+    @pytest.mark.parametrize(
+        ("schemas", "expected"),
+        [
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Integer()})], Schema({"Column1": Integer()})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber()})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": Boolean()})], Schema({"Column1": Boolean()})),
+            ([Schema({"Column1": String()}), Schema({"Column1": String()})], Schema({"Column1": String()})),
+            ([Schema({"Column1": Anything()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber()})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": String()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": String()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": String()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
+            ([Schema({"Column1": String()}), Schema({"Column1": Anything()})], Schema({"Column1": Anything()})),
+
+            ([Schema({"Column1": Integer(True)}), Schema({"Column1": Integer()})], Schema({"Column1": Integer(True)})),
+            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(True)})),
+            ([Schema({"Column1": Boolean(True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Boolean(True)})),
+            ([Schema({"Column1": String(True)}), Schema({"Column1": String()})], Schema({"Column1": String(True)})),
+            ([Schema({"Column1": Anything(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer(True)}), Schema({"Column1": RealNumber()})], Schema({"Column1": RealNumber(True)})),
+            ([Schema({"Column1": Integer(True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer(True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": Boolean()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": RealNumber(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Boolean(True)}), Schema({"Column1": String()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Boolean(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": String(True)}), Schema({"Column1": Anything()})], Schema({"Column1": Anything(True)})),
+
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Integer(True)})], Schema({"Column1": Integer(True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": RealNumber(True)})], Schema({"Column1": RealNumber(True)})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": Boolean(True)})], Schema({"Column1": Boolean(True)})),
+            ([Schema({"Column1": String()}), Schema({"Column1": String(True)})], Schema({"Column1": String(True)})),
+            ([Schema({"Column1": Anything()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": RealNumber(True)})], Schema({"Column1": RealNumber(True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Boolean(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": String(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Integer()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Boolean(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": String(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": RealNumber()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": String(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": Boolean()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
+            ([Schema({"Column1": String()}), Schema({"Column1": Anything(True)})], Schema({"Column1": Anything(True)})),
+        ],
+        ids=[
+            "Integer Integer",
+            "RealNumber RealNumber",
+            "Boolean Boolean",
+            "String String",
+            "Anything Anything",
+            "Integer RealNumber",
+            "Integer Boolean",
+            "Integer String",
+            "Integer Anything",
+            "RealNumber Boolean",
+            "RealNumber String",
+            "RealNumber Anything",
+            "Boolean String",
+            "Boolean Anything",
+            "String Anything",
+
+            "Integer(null) Integer",
+            "RealNumber(null) RealNumber",
+            "Boolean(null) Boolean",
+            "String(null) String",
+            "Anything(null) Anything",
+            "Integer(null) RealNumber",
+            "Integer(null) Boolean",
+            "Integer(null) String",
+            "Integer(null) Anything",
+            "RealNumber(null) Boolean",
+            "RealNumber(null) String",
+            "RealNumber(null) Anything",
+            "Boolean(null) String",
+            "Boolean(null) Anything",
+            "String(null) Anything",
+
+            "Integer Integer(null)",
+            "RealNumber RealNumber(null)",
+            "Boolean Boolean(null)",
+            "String String(null)",
+            "Anything Anything(null)",
+            "Integer RealNumber(null)",
+            "Integer Boolean(null)",
+            "Integer String(null)",
+            "Integer Anything(null)",
+            "RealNumber Boolean(null)",
+            "RealNumber String(null)",
+            "RealNumber Anything(null)",
+            "Boolean String(null)",
+            "Boolean Anything(null)",
+            "String Anything(null)",
+        ]
+    )
+    def test_should_return_merged_schema(self, schemas: list[Schema], expected: Schema):
+        assert Schema.merge_multiple_schemas(schemas) == expected
+        schemas.reverse()
+        assert Schema.merge_multiple_schemas(schemas) == expected  # test the reversed list because the first parameter is handled differently
 
 
 class TestReprMarkdown:


### PR DESCRIPTION
Closes #127.

### Summary of Changes

feat: Added ability to `Table.add_row` and `Table.add_rows` to allow new rows with different schemas
feat: Added the method `Row.sort_columns` to sort the columns in a row
feat: Added new static method Schema.merge_multiple_schemas to merge multiple schemas into one
feat: Changed `Table.from_rows` to accept different schemas

### Additional Context

Waiting for #322 for updates with ColumnTypes
