### PR TITLE
test: Add empty list testcase for `replace_column`

### DIFF
--- a/tests/safeds/data/tabular/containers/_table/test_replace_column.py
+++ b/tests/safeds/data/tabular/containers/_table/test_replace_column.py
@@ -47,8 +47,25 @@ from safeds.exceptions import (
                 },
             ),
         ),
+        (
+            Table(
+                {
+                    "A": [1, 2, 3],
+                    "B": [4, 5, 6],
+                    "C": ["a", "b", "c"],
+                },
+            ),
+            "C",
+            [],
+            Table(
+                {
+                    "A": [1, 2, 3],
+                    "B": [4, 5, 6],
+                },
+            ),
+        ),
     ],
-    ids=["multiple Columns", "one Column"],
+    ids=["multiple Columns", "one Column", "empty"],
 )
 def test_should_replace_column(table: Table, column_name: str, columns: list[Column], expected: Table) -> None:
     result = table.replace_column(column_name, columns)


### PR DESCRIPTION
Closes #301.

### Summary of Changes

Added a new testcase for `replace_column` to verify that the method can handle an empty list as argument.
