### PR TITLE
fix: remove default value of `radius` parameter of `blur`

### DIFF
--- a/src/safeds/data/image/containers/_image.py
+++ b/src/safeds/data/image/containers/_image.py
@@ -12,7 +12,7 @@ from PIL.Image import Image as PillowImage
 from PIL.Image import open as open_image
 
 from safeds.data.image.typing import ImageFormat
-from safeds.exceptions._data import WrongFileExtensionError
+from safeds.exceptions import WrongFileExtensionError
 
 
 class Image:
@@ -352,15 +352,15 @@ class Image:
         image_copy._image = ImageEnhance.Contrast(image_copy._image).enhance(factor)
         return image_copy
 
-    def blur(self, radius: int = 1) -> Image:
+    def blur(self, radius: int) -> Image:
         """
         Return the blurred image.
 
         Parameters
         ----------
         radius : int
-             Radius is directly proportional to the blur value. The radius is equal to the amount of pixels united in each direction.
-             A Radius of 1 will result in a united box of 9 pixels.
+             Radius is directly proportional to the blur value. The radius is equal to the amount of pixels united in
+             each direction. A radius of 1 will result in a united box of 9 pixels.
 
         Returns
         -------


### PR DESCRIPTION
### Summary of Changes

* Remove default value of `radius` parameter of `Image.blur` to be in line with other methods.
