### PR TITLE
feat: improve error handling of `column.stability` when given a column that contains only None

### DIFF
--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -504,7 +504,7 @@ class Column(Sequence[T]):
         \frac{\text{number of occurrences of most common non-null value}}{\text{number of non-null values}}
         $$
 
-        The stability cannot be calculated for a column with only null values.
+        The stability is not definded for a column with only null values.
 
         Returns
         -------
@@ -520,7 +520,7 @@ class Column(Sequence[T]):
             raise ColumnSizeError("> 0", "0")
 
         if self.all(lambda x: x is None):
-            raise ValueError("Stability cannot be calculated for a column with only null values.")
+            raise ValueError("Stability is not definded for a column with only null values.")
 
         return self._data.value_counts()[self.mode()[0]] / self._data.count()
 

--- a/src/safeds/data/tabular/containers/_column.py
+++ b/src/safeds/data/tabular/containers/_column.py
@@ -504,6 +504,8 @@ class Column(Sequence[T]):
         \frac{\text{number of occurrences of most common non-null value}}{\text{number of non-null values}}
         $$
 
+        The stability cannot be calculated for a column with only null values.
+
         Returns
         -------
         stability : float
@@ -516,6 +518,10 @@ class Column(Sequence[T]):
         """
         if self._data.size == 0:
             raise ColumnSizeError("> 0", "0")
+
+        if self.all(lambda x: x is None):
+            raise ValueError("Stability cannot be calculated for a column with only null values.")
+
         return self._data.value_counts()[self.mode()[0]] / self._data.count()
 
     def standard_deviation(self) -> float:

--- a/tests/safeds/data/tabular/containers/_column/test_stability.py
+++ b/tests/safeds/data/tabular/containers/_column/test_stability.py
@@ -33,5 +33,5 @@ def test_should_raise_column_size_error_if_column_is_empty() -> None:
 
 def test_should_raise_value_error_if_column_contains_only_none() -> None:
     column: Column[Any] = Column("A", [None, None])
-    with pytest.raises(ValueError, match="Stability cannot be calculated for a column with only null values."):
+    with pytest.raises(ValueError, match="Stability is not definded for a column with only null values."):
         column.stability()

--- a/tests/safeds/data/tabular/containers/_column/test_stability.py
+++ b/tests/safeds/data/tabular/containers/_column/test_stability.py
@@ -25,7 +25,13 @@ def test_should_return_stability_of_column(values: list[Any], expected: float) -
     assert column.stability() == expected
 
 
-def test_should_raise_if_column_is_empty() -> None:
+def test_should_raise_column_size_error_if_column_is_empty() -> None:
     column: Column[Any] = Column("A", [])
-    with pytest.raises(ColumnSizeError):
+    with pytest.raises(ColumnSizeError, match="Expected a column of size > 0 but got column of size 0."):
+        column.stability()
+
+
+def test_should_raise_value_error_if_column_contains_only_none() -> None:
+    column: Column[Any] = Column("A", [None, None])
+    with pytest.raises(ValueError, match="Stability cannot be calculated for a column with only null values."):
         column.stability()


### PR DESCRIPTION
Closes #319 

### Summary of Changes

The docstring of the method clarifies that the stability is not defined if a column contains only null values.
The method raises a ValueError if the column contains only null values.

<!-- Please provide a summary of changes in this pull request, ensuring all changes are explained. -->
