### PR TITLE
feat: Rangescalar and other transformer implementations now pass exceptions from sklearn

### DIFF
--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -4,6 +4,7 @@ import warnings
 from typing import Any
 
 import pandas as pd
+import sklearn.exceptions as sk_exceptions
 from sklearn.impute import SimpleImputer as sk_SimpleImputer
 
 from safeds.data.tabular.containers import Table
@@ -126,7 +127,7 @@ class Imputer(TableTransformer):
                 raise UnknownColumnNameError(missing_columns)
 
         if table.number_of_rows == 0:
-            raise ValueError("The Imputer cannot be fitted because the table contains 0 rows")
+            raise sk_exceptions.NotFittedError("The Imputer cannot be fitted because the table contains 0 rows")
 
         if (isinstance(self._strategy, Imputer.Strategy.Mean | Imputer.Strategy.Median)) and table.keep_only_columns(
             column_names,

--- a/src/safeds/data/tabular/transformation/_label_encoder.py
+++ b/src/safeds/data/tabular/transformation/_label_encoder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 
+import sklearn.exceptions as sk_exceptions
 from sklearn.preprocessing import OrdinalEncoder as sk_OrdinalEncoder
 
 from safeds.data.tabular.containers import Table
@@ -52,7 +53,7 @@ class LabelEncoder(InvertibleTableTransformer):
                 raise UnknownColumnNameError(missing_columns)
 
         if table.number_of_rows == 0:
-            raise ValueError("The LabelEncoder cannot transform the table because it contains 0 rows")
+            raise sk_exceptions.NotFittedError("The LabelEncoder cannot transform the table because it contains 0 rows")
 
         if table.keep_only_columns(column_names).remove_columns_with_non_numerical_values().number_of_columns > 0:
             warnings.warn(

--- a/src/safeds/data/tabular/transformation/_one_hot_encoder.py
+++ b/src/safeds/data/tabular/transformation/_one_hot_encoder.py
@@ -5,6 +5,7 @@ from collections import Counter
 from typing import Any
 
 import numpy as np
+import sklearn.exceptions as sk_exceptions
 
 from safeds.data.tabular.containers import Column, Table
 from safeds.data.tabular.transformation._table_transformer import (
@@ -101,7 +102,7 @@ class OneHotEncoder(InvertibleTableTransformer):
                 raise UnknownColumnNameError(missing_columns)
 
         if table.number_of_rows == 0:
-            raise ValueError("The OneHotEncoder cannot be fitted because the table contains 0 rows")
+            raise sk_exceptions.NotFittedError("The OneHotEncoder cannot be fitted because the table contains 0 rows")
 
         if table.keep_only_columns(column_names).remove_columns_with_non_numerical_values().number_of_columns > 0:
             warnings.warn(

--- a/src/safeds/data/tabular/transformation/_range_scaler.py
+++ b/src/safeds/data/tabular/transformation/_range_scaler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sklearn.exceptions as sk_exceptions
 from sklearn.preprocessing import MinMaxScaler as sk_MinMaxScaler
 
 from safeds.data.tabular.containers import Table
@@ -83,7 +84,7 @@ class RangeScaler(InvertibleTableTransformer):
             )
 
         if table.number_of_rows == 0:
-            raise ValueError("The RangeScaler cannot be fitted because the table contains 0 rows")
+            raise sk_exceptions.NotFittedError("The RangeScaler cannot be fitted because the table contains 0 rows")
 
         wrapped_transformer = sk_MinMaxScaler((self._minimum, self._maximum))
         wrapped_transformer.fit(table._data[column_names])

--- a/src/safeds/data/tabular/transformation/_standard_scaler.py
+++ b/src/safeds/data/tabular/transformation/_standard_scaler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sklearn.exceptions as sk_exceptions
 from sklearn.preprocessing import StandardScaler as sk_StandardScaler
 
 from safeds.data.tabular.containers import Table
@@ -66,7 +67,7 @@ class StandardScaler(InvertibleTableTransformer):
             )
 
         if table.number_of_rows == 0:
-            raise ValueError("The StandardScaler cannot be fitted because the table contains 0 rows")
+            raise sk_exceptions.NotFittedError("The StandardScaler cannot be fitted because the table contains 0 rows")
 
         wrapped_transformer = sk_StandardScaler()
         wrapped_transformer.fit(table._data[column_names])

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -50,8 +50,9 @@ class TestFit:
 
     @pytest.mark.parametrize("strategy", strategies(), ids=lambda x: x.__class__.__name__)
     def test_should_raise_if_table_contains_no_rows(self, strategy: ImputerStrategy) -> None:
-        with pytest.raises(sk_exceptions.NotFittedError,
-                           match=r"The Imputer cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(
+            sk_exceptions.NotFittedError, match=r"The Imputer cannot be fitted because the table contains 0 rows",
+        ):
             Imputer(strategy).fit(Table({"col1": []}), ["col1"])
 
     @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -1,4 +1,5 @@
 import pytest
+import sklearn.exceptions as sk_exceptions
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import Imputer
 from safeds.data.tabular.typing import ImputerStrategy
@@ -49,7 +50,8 @@ class TestFit:
 
     @pytest.mark.parametrize("strategy", strategies(), ids=lambda x: x.__class__.__name__)
     def test_should_raise_if_table_contains_no_rows(self, strategy: ImputerStrategy) -> None:
-        with pytest.raises(ValueError, match=r"The Imputer cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(sk_exceptions.NotFittedError,
+                           match=r"The Imputer cannot be fitted because the table contains 0 rows"):
             Imputer(strategy).fit(Table({"col1": []}), ["col1"])
 
     @pytest.mark.parametrize(

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -51,7 +51,8 @@ class TestFit:
     @pytest.mark.parametrize("strategy", strategies(), ids=lambda x: x.__class__.__name__)
     def test_should_raise_if_table_contains_no_rows(self, strategy: ImputerStrategy) -> None:
         with pytest.raises(
-            sk_exceptions.NotFittedError, match=r"The Imputer cannot be fitted because the table contains 0 rows",
+            sk_exceptions.NotFittedError,
+            match=r"The Imputer cannot be fitted because the table contains 0 rows",
         ):
             Imputer(strategy).fit(Table({"col1": []}), ["col1"])
 

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -17,8 +17,10 @@ class TestFit:
             LabelEncoder().fit(table, ["col2", "col3"])
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(sk_exceptions.NotFittedError,
-                           match=r"The LabelEncoder cannot transform the table because it contains 0 rows"):
+        with pytest.raises(
+            sk_exceptions.NotFittedError,
+            match=r"The LabelEncoder cannot transform the table because it contains 0 rows",
+        ):
             LabelEncoder().fit(Table({"col1": []}), ["col1"])
 
     def test_should_warn_if_table_contains_numerical_data(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_label_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_label_encoder.py
@@ -1,4 +1,5 @@
 import pytest
+import sklearn.exceptions as sk_exceptions
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import LabelEncoder
 from safeds.exceptions import NonNumericColumnError, TransformerNotFittedError, UnknownColumnNameError
@@ -16,7 +17,8 @@ class TestFit:
             LabelEncoder().fit(table, ["col2", "col3"])
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(ValueError, match=r"The LabelEncoder cannot transform the table because it contains 0 rows"):
+        with pytest.raises(sk_exceptions.NotFittedError,
+                           match=r"The LabelEncoder cannot transform the table because it contains 0 rows"):
             LabelEncoder().fit(Table({"col1": []}), ["col1"])
 
     def test_should_warn_if_table_contains_numerical_data(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -22,8 +22,9 @@ class TestFit:
             OneHotEncoder().fit(table, ["col2", "col3"])
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(sk_exceptions.NotFittedError,
-                           match=r"The OneHotEncoder cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(
+            sk_exceptions.NotFittedError, match=r"The OneHotEncoder cannot be fitted because the table contains 0 rows",
+        ):
             OneHotEncoder().fit(Table({"col1": []}), ["col1"])
 
     def test_should_warn_if_table_contains_numerical_data(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -23,7 +23,8 @@ class TestFit:
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
         with pytest.raises(
-            sk_exceptions.NotFittedError, match=r"The OneHotEncoder cannot be fitted because the table contains 0 rows",
+            sk_exceptions.NotFittedError,
+            match=r"The OneHotEncoder cannot be fitted because the table contains 0 rows",
         ):
             OneHotEncoder().fit(Table({"col1": []}), ["col1"])
 

--- a/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
+++ b/tests/safeds/data/tabular/transformation/test_one_hot_encoder.py
@@ -1,4 +1,5 @@
 import pytest
+import sklearn.exceptions as sk_exceptions
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import OneHotEncoder
 from safeds.exceptions import (
@@ -21,7 +22,8 @@ class TestFit:
             OneHotEncoder().fit(table, ["col2", "col3"])
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(ValueError, match=r"The OneHotEncoder cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(sk_exceptions.NotFittedError,
+                           match=r"The OneHotEncoder cannot be fitted because the table contains 0 rows"):
             OneHotEncoder().fit(Table({"col1": []}), ["col1"])
 
     def test_should_warn_if_table_contains_numerical_data(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -31,7 +31,8 @@ class TestFit:
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
         with pytest.raises(
-            sk_exceptions.NotFittedError, match=r"The RangeScaler cannot be fitted because the table contains 0 rows",
+            sk_exceptions.NotFittedError,
+            match=r"The RangeScaler cannot be fitted because the table contains 0 rows",
         ):
             RangeScaler().fit(Table({"col1": []}), ["col1"])
 

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -30,8 +30,9 @@ class TestFit:
             RangeScaler().fit(Table({"col1": ["a", "b"], "col2": [1, "c"]}), ["col1", "col2"])
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(sk_exceptions.NotFittedError,
-                           match=r"The RangeScaler cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(
+            sk_exceptions.NotFittedError, match=r"The RangeScaler cannot be fitted because the table contains 0 rows",
+        ):
             RangeScaler().fit(Table({"col1": []}), ["col1"])
 
     def test_should_not_change_original_transformer(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_range_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_range_scaler.py
@@ -1,4 +1,5 @@
 import pytest
+import sklearn.exceptions as sk_exceptions
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import RangeScaler
 from safeds.exceptions import NonNumericColumnError, TransformerNotFittedError, UnknownColumnNameError
@@ -29,7 +30,8 @@ class TestFit:
             RangeScaler().fit(Table({"col1": ["a", "b"], "col2": [1, "c"]}), ["col1", "col2"])
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(ValueError, match=r"The RangeScaler cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(sk_exceptions.NotFittedError,
+                           match=r"The RangeScaler cannot be fitted because the table contains 0 rows"):
             RangeScaler().fit(Table({"col1": []}), ["col1"])
 
     def test_should_not_change_original_transformer(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_standard_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_standard_scaler.py
@@ -29,8 +29,9 @@ class TestFit:
             )
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(sk_exceptions.NotFittedError,
-                           match=r"The StandardScaler cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(
+            sk_exceptions.NotFittedError, match=r"The StandardScaler cannot be fitted because the table contains 0 rows",
+        ):
             StandardScaler().fit(Table({"col1": []}), ["col1"])
 
     def test_should_not_change_original_transformer(self) -> None:

--- a/tests/safeds/data/tabular/transformation/test_standard_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_standard_scaler.py
@@ -30,7 +30,8 @@ class TestFit:
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
         with pytest.raises(
-            sk_exceptions.NotFittedError, match=r"The StandardScaler cannot be fitted because the table contains 0 rows",
+            sk_exceptions.NotFittedError,
+            match=r"The StandardScaler cannot be fitted because the table contains 0 rows",
         ):
             StandardScaler().fit(Table({"col1": []}), ["col1"])
 

--- a/tests/safeds/data/tabular/transformation/test_standard_scaler.py
+++ b/tests/safeds/data/tabular/transformation/test_standard_scaler.py
@@ -1,4 +1,5 @@
 import pytest
+import sklearn.exceptions as sk_exceptions
 from safeds.data.tabular.containers import Table
 from safeds.data.tabular.transformation import StandardScaler
 from safeds.exceptions import NonNumericColumnError, TransformerNotFittedError, UnknownColumnNameError
@@ -28,7 +29,8 @@ class TestFit:
             )
 
     def test_should_raise_if_table_contains_no_rows(self) -> None:
-        with pytest.raises(ValueError, match=r"The StandardScaler cannot be fitted because the table contains 0 rows"):
+        with pytest.raises(sk_exceptions.NotFittedError,
+                           match=r"The StandardScaler cannot be fitted because the table contains 0 rows"):
             StandardScaler().fit(Table({"col1": []}), ["col1"])
 
     def test_should_not_change_original_transformer(self) -> None:


### PR DESCRIPTION
Closes #326 

### Summary of Changes

* Rangescalar and other transformer implementations now pass exceptions from sk-learn when fitting on an empty table
