### PR TITLE
fix: better error handling in `invert_colors`

### DIFF
--- a/src/safeds/data/image/containers/_image.py
+++ b/src/safeds/data/image/containers/_image.py
@@ -381,7 +381,7 @@ class Image:
             The image with inverted colors.
         """
         image_copy = copy.deepcopy(self)
-        image_copy._image = ImageOps.invert(image_copy._image)
+        image_copy._image = ImageOps.invert(image_copy._image.convert("RGB"))
         return image_copy
 
     def rotate_right(self) -> Image:


### PR DESCRIPTION
Closes #421.

### Summary of Changes

* `invert_colors` can now handle other image formats than `RGB`.
* (TODO:) `invert_colors` now raises user-friendly errors rather than passing on those from the underlying `ImageOps` library.