### PR TITLE
docs: Add link to `Getting started` tutorial under `Tutorials` section on documentation webpage

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
     - README.md
     - Changelog: CHANGELOG.md
   - Tutorials:
+    - Getting started: tutorials/getting_started.ipynb
     - Data Processing: tutorials/data_processing.ipynb
     - Data Visualization: tutorials/data_visualization.ipynb
     - Machine Learning: tutorials/machine_learning.ipynb


### PR DESCRIPTION
Closes #423.

### Summary of Changes

* The `Getting started` tutorial can now be found under `Tutorials` on the documentation webpage.