### PR TITLE
ci: compute coverage during Python 3.11 run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,6 @@ jobs:
       working-directory: .
       python-version: ${{ matrix.python-version }}
       module-name: safeds
-      coverage: ${{ matrix.python-version == '3.10' }}
+      coverage: ${{ matrix.python-version == '3.11' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,6 @@ jobs:
       working-directory: .
       python-version: ${{ matrix.python-version }}
       module-name: safeds
-      coverage: ${{ matrix.python-version == '3.10' }}
+      coverage: ${{ matrix.python-version == '3.11' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Summary of Changes

Compute coverage during the Python 3.11 run since it's slightly faster than the 3.10 run.