### PR TITLE
docs: Fix broken link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ You can find the full documentation [here](https://stdlib.safeds.com).
 We welcome contributions from everyone. As a starting point, check the following resources:
 
 * [Setting up a development environment](https://stdlib.safeds.com/en/latest/development/environment/)
-* [Project guidelines](https://stdlib.safeds.com/en/latest/development/guidelines/)
+* [Project guidelines](https://stdlib.safeds.com/en/latest/development/project_guidelines/)
 * [Contributing page](https://github.com/Safe-DS/Stdlib/contribute)
 
 If you need further help, please [use our discussion forum][forum].


### PR DESCRIPTION
Closes #441.

### Summary of Changes

Fixed the broken link to our project guidelines in our README, which was a regression from #427.