### PR TITLE
docs: fix griffe warnings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/Safe-DS/Stdlib
 repo_name: Safe-DS/Stdlib
 edit_uri: edit/main/docs/
 site_url: !ENV READTHEDOCS_CANONICAL_URL
+strict: true
 
 nav:
   - Home:

--- a/src/safeds/data/image/containers/_image.py
+++ b/src/safeds/data/image/containers/_image.py
@@ -389,8 +389,9 @@ class Image:
 
         Parameters
         ----------
-        factor: The amount of sharpness to be applied to the image.
-        Factor 1.0 is considered to be neutral and does not make any changes.
+        factor : float
+            The amount of sharpness to be applied to the image. Factor 1.0 is considered to be neutral and does not make
+            any changes.
 
         Returns
         -------

--- a/src/safeds/data/tabular/containers/_tagged_table.py
+++ b/src/safeds/data/tabular/containers/_tagged_table.py
@@ -617,36 +617,36 @@ class TaggedTable(Table):
 
     def replace_column(self, old_column_name: str, new_columns: list[Column]) -> TaggedTable:
         """
-                Replace the specified old column by a list of new columns.
+        Replace the specified old column by a list of new columns.
 
-                The order of columns is kept.
+        If the column to be replaced is the target column, it must be replaced by exactly one column. That column
+        becomes the new target column. If the column to be replaced is a feature column, the new columns that replace it
+        all become feature columns.
 
-                If the column to be replaced is the target column, it must be replaced by exactly one column. That column becomes the new target column.
-        If the column to be replaced is a feature column, the new columns that replace it all become feature columns.
-                This table is not modified.
+        The order of columns is kept. This table is not modified.
 
         Parameters
         ----------
-                old_column_name : str
-                    The name of the column to be replaced.
-                new_columns : list[Column]
-                    The new columns replacing the old column.
+        old_column_name : str
+            The name of the column to be replaced.
+        new_columns : list[Column]
+            The new columns replacing the old column.
 
         Returns
         -------
-                result : TaggedTable
-                    A table with the old column replaced by the new column.
+        result : TaggedTable
+            A table with the old column replaced by the new column.
 
         Raises
         ------
-                UnknownColumnNameError
-                    If the old column does not exist.
-                DuplicateColumnNameError
-                    If the new column already exists and the existing column is not affected by the replacement.
-                ColumnSizeError
-                    If the size of the column does not match the amount of rows.
-                IllegalSchemaModificationError
-                    If the target column would be removed or replaced by more than one column.
+        UnknownColumnNameError
+            If the old column does not exist.
+        DuplicateColumnNameError
+            If the new column already exists and the existing column is not affected by the replacement.
+        ColumnSizeError
+            If the size of the column does not match the amount of rows.
+        IllegalSchemaModificationError
+            If the target column would be removed or replaced by more than one column.
         """
         if old_column_name == self.target.name:
             if len(new_columns) != 1:

--- a/src/safeds/data/tabular/transformation/_range_scaler.py
+++ b/src/safeds/data/tabular/transformation/_range_scaler.py
@@ -17,6 +17,7 @@ class RangeScaler(InvertibleTableTransformer):
         The minimum of the new range after the transformation
     maximum : float
         The maximum of the new range after the transformation
+
     Raises
     ------
     ValueError


### PR DESCRIPTION
Closes #429

### Summary of Changes

* Fix griffe warnings
* Enable strict mode of `mkdocs` to fail on warnings