### PR TITLE
feat: rename several `Table` methods for consistency

### DIFF
--- a/docs/development/project_guidelines.md
+++ b/docs/development/project_guidelines.md
@@ -265,13 +265,13 @@ Passing values that are commonly used together around separately is tedious, ver
 !!! success "**DO** (client code):"
 
     ```py
-    training_data, validation_data = split(full_data)
+    training_data, validation_data = split_rows(full_data)
     ```
 
 !!! failure "**DON'T** (client code):"
 
     ```py
-    training_feature_vectors, validation_feature_vectors, training_target_values, validation_target_values = split(feature_vectors, target_values)
+    training_feature_vectors, validation_feature_vectors, training_target_values, validation_target_values = split_rows(feature_vectors, target_values)
     ```
 
 ## Docstrings

--- a/docs/tutorials/getting_started.ipynb
+++ b/docs/tutorials/getting_started.ipynb
@@ -52,7 +52,7 @@
    "execution_count": 2,
    "outputs": [],
    "source": [
-    "split_tuple = titanic.split(0.60)\n",
+    "split_tuple = titanic.split_rows(0.60)\n",
     "\n",
     "train_table = split_tuple[0]\n",
     "test_table = split_tuple[1]\n",

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1595,7 +1595,7 @@ class Table:
         rows.sort(key=functools.cmp_to_key(comparator))
         return Table.from_rows(rows)
 
-    def split(self, percentage_in_first: float) -> tuple[Table, Table]:
+    def split_rows(self, percentage_in_first: float) -> tuple[Table, Table]:
         """
         Split the table into two new tables.
 
@@ -1621,7 +1621,7 @@ class Table:
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table.from_dict({"temperature": [10, 15, 20, 25, 30], "sales": [54, 74, 90, 206, 210]})
-        >>> slices = table.split(0.4)
+        >>> slices = table.split_rows(0.4)
         >>> slices[0]
            temperature  sales
         0           10     54

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -1048,7 +1048,7 @@ class Table:
 
     _T = TypeVar("_T")
 
-    def group_by(self, key_selector: Callable[[Row], _T]) -> dict[_T, Table]:
+    def group_rows_by(self, key_selector: Callable[[Row], _T]) -> dict[_T, Table]:
         """
         Return a dictionary with the output tables as values and the keys from the key_selector.
 

--- a/src/safeds/data/tabular/containers/_table.py
+++ b/src/safeds/data/tabular/containers/_table.py
@@ -695,7 +695,7 @@ class Table:
     # Information
     # ------------------------------------------------------------------------------------------------------------------
 
-    def summary(self) -> Table:
+    def summarize_statistics(self) -> Table:
         """
         Return a table with a number of statistical key values.
 
@@ -710,7 +710,7 @@ class Table:
         --------
         >>> from safeds.data.tabular.containers import Table
         >>> table = Table.from_dict({"a": [1, 3], "b": [2, 4]})
-        >>> table.summary()
+        >>> table.summarize_statistics()
                       metrics                   a                   b
         0             maximum                   3                   4
         1             minimum                   1                   2

--- a/tests/safeds/data/tabular/containers/_table/test_group_rows_by.py
+++ b/tests/safeds/data/tabular/containers/_table/test_group_rows_by.py
@@ -30,6 +30,6 @@ from safeds.data.tabular.containers import Table
     ],
     ids=["select by row1", "different types in column", "empty table", "table with no rows"],
 )
-def test_group_by(table: Table, selector: Callable, expected: dict) -> None:
-    out = table.group_by(selector)
+def test_should_group_rows(table: Table, selector: Callable, expected: dict) -> None:
+    out = table.group_rows_by(selector)
     assert out == expected

--- a/tests/safeds/data/tabular/containers/_table/test_split_rows.py
+++ b/tests/safeds/data/tabular/containers/_table/test_split_rows.py
@@ -34,7 +34,7 @@ def test_should_split_table(
     result_train_table: Table,
     percentage_in_first: int,
 ) -> None:
-    train_table, test_table = table.split(percentage_in_first)
+    train_table, test_table = table.split_rows(percentage_in_first)
     assert result_test_table == test_table
     assert result_train_table.schema == train_table.schema
     assert result_train_table == train_table
@@ -52,10 +52,10 @@ def test_should_raise_if_value_not_in_range(percentage_in_first: float) -> None:
     table = Table({"col1": [1, 2, 1], "col2": [1, 2, 4]})
 
     with pytest.raises(ValueError, match=r"The given percentage is not between 0 and 1"):
-        table.split(percentage_in_first)
+        table.split_rows(percentage_in_first)
 
 
 def test_should_split_empty_table() -> None:
-    t1, t2 = Table().split(0.4)
+    t1, t2 = Table().split_rows(0.4)
     assert t1.number_of_rows == 0
     assert t2.number_of_rows == 0

--- a/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
+++ b/tests/safeds/data/tabular/containers/_table/test_summarize_statistics.py
@@ -135,6 +135,6 @@ from safeds.data.tabular.containers import Table
     ],
     ids=["Column of integers and Column of characters", "empty", "empty with columns", "Column of None"],
 )
-def test_should_make_summary(table: Table, expected: Table) -> None:
-    assert expected.schema == table.summary().schema
-    assert expected == table.summary()
+def test_should_summarize_statistics(table: Table, expected: Table) -> None:
+    assert expected.schema == table.summarize_statistics().schema
+    assert expected == table.summarize_statistics()


### PR DESCRIPTION
Closes #439

### Summary of Changes

* Rename `group_by` to `group_rows_by`
* Rename `split` to `split_rows`
* Rename `summary` to `summarize_statistics`
