### PR TITLE
fix: don't warn if `Imputer` transforms column without missing values

### DIFF
--- a/src/safeds/data/tabular/transformation/_imputer.py
+++ b/src/safeds/data/tabular/transformation/_imputer.py
@@ -210,17 +210,6 @@ class Imputer(TableTransformer):
         if table.number_of_rows == 0:
             raise ValueError("The Imputer cannot transform the table because it contains 0 rows")
 
-        if table.keep_only_columns(self._column_names).remove_columns_with_missing_values().number_of_columns > 0:
-            warnings.warn(
-                (
-                    "The columns"
-                    f" {table.keep_only_columns(self._column_names).remove_columns_with_missing_values().column_names} have"
-                    " no missing values, so the Imputer did not change these columns"
-                ),
-                UserWarning,
-                stacklevel=2,
-            )
-
         data = table._data.copy()
         data[self._column_names] = pd.DataFrame(
             self._wrapped_transformer.transform(data[self._column_names]),

--- a/tests/safeds/data/tabular/transformation/test_imputer.py
+++ b/tests/safeds/data/tabular/transformation/test_imputer.py
@@ -161,14 +161,6 @@ class TestTransform:
         with pytest.raises(TransformerNotFittedError, match=r"The transformer has not been fitted yet."):
             transformer.transform(table)
 
-    @pytest.mark.parametrize("strategy", strategies(), ids=lambda x: x.__class__.__name__)
-    def test_should_warn_if_no_missing_values(self, strategy: ImputerStrategy) -> None:
-        with pytest.warns(
-            UserWarning,
-            match=r"The columns \['col1'\] have no missing values, so the Imputer did not change these columns",
-        ):
-            Imputer(strategy).fit(Table({"col1": [1, 2, 3]}), ["col1"]).transform(Table({"col1": [1, 2, 3, 4, 5]}))
-
 
 class TestIsFitted:
     @pytest.mark.parametrize("strategy", strategies(), ids=lambda x: x.__class__.__name__)


### PR DESCRIPTION
### Summary of Changes

* Don't warn in `Imputer` if some columns of the `Table` passed to `transform` don't have missing values. The `Imputer` is used to guarantee that no missing values exist in a column. We should not need to check beforehand whether a column actually has missing values.